### PR TITLE
feat: email-case-insensitivity

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -34,7 +34,7 @@ export class UsersService {
   create(createUserDto: CreateUserDto): Promise<Users> {
     const user = new Users();
     user.login = createUserDto.login;
-    user.email = createUserDto.email;
+    user.email = createUserDto.email.toLowerCase();
     user.password = createUserDto.password;
     return this.usersRepository.save(user);
   }


### PR DESCRIPTION
Сейчас, например, почта hexlet@mail.ru и HEXLET@mail.ru сохраняются как две разных почты. Я сделал приведение емейла к нижнему регистру во время создания пользователя.