### PR TITLE
Added sending errors via sentry

### DIFF
--- a/app/javascript/index.jsx
+++ b/app/javascript/index.jsx
@@ -4,6 +4,8 @@ import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import * as Sentry from '@sentry/react';
+import { BrowserTracing } from '@sentry/tracing';
 // import gon from 'gon';
 
 import { BrowserRouter } from 'react-router-dom';
@@ -24,6 +26,12 @@ export default async () => {
   });
   const store = configureStore({
     reducer: rootReducer,
+  });
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [new BrowserTracing()],
+    tracesSampleRate: 1.0,
   });
 
   // store.dispatch(setupState(gon));

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "@nestjs/websockets": "^9.2.0",
         "@popperjs/core": "^2.11.5",
         "@reduxjs/toolkit": "^1.8.2",
+        "@sentry/react": "^7.25.0",
+        "@sentry/tracing": "^7.25.0",
         "@types/bcrypt": "^5.0.0",
         "array-includes": "^3.1.5",
         "array.prototype.flat": "^1.3.0",
@@ -5366,6 +5368,110 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
+      "dependencies": {
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
+      "dependencies": {
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/react": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.25.0.tgz",
+      "integrity": "sha512-U8i7fCpM7bxtcbmppvsvsh4lA6XoME09QG5Eskxj9rff9B5j1DqWAJLvwfuHHTqoM4Sw1ITvymuxg9+syusc0g==",
+      "dependencies": {
+        "@sentry/browser": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.25.0.tgz",
+      "integrity": "sha512-8KjMfJu3+7IcU+65r+sH0rDVTBxhcTZkGTURqFzty9RO3fpY6dTtXZIB3Pni9m+rF6Sz+6HrMKopD9g0yW17XQ==",
+      "dependencies": {
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
+      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
+      "dependencies": {
+        "@sentry/types": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -33951,6 +34057,99 @@
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
           "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
           "dev": true
+        }
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
+      "requires": {
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
+      "requires": {
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/react": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.25.0.tgz",
+      "integrity": "sha512-U8i7fCpM7bxtcbmppvsvsh4lA6XoME09QG5Eskxj9rff9B5j1DqWAJLvwfuHHTqoM4Sw1ITvymuxg9+syusc0g==",
+      "requires": {
+        "@sentry/browser": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.25.0.tgz",
+      "integrity": "sha512-8KjMfJu3+7IcU+65r+sH0rDVTBxhcTZkGTURqFzty9RO3fpY6dTtXZIB3Pni9m+rF6Sz+6HrMKopD9g0yW17XQ==",
+      "requires": {
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w=="
+    },
+    "@sentry/utils": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
+      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
+      "requires": {
+        "@sentry/types": "7.25.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@nestjs/websockets": "^9.2.0",
     "@popperjs/core": "^2.11.5",
     "@reduxjs/toolkit": "^1.8.2",
+    "@sentry/react": "^7.25.0",
+    "@sentry/tracing": "^7.25.0",
     "@types/bcrypt": "^5.0.0",
     "array-includes": "^3.1.5",
     "array.prototype.flat": "^1.3.0",


### PR DESCRIPTION
runit #19 
Добавляет базовую поддержку Sentry SDK в проект. При инициализации Sentry нужно было указать dsn, для этого я завёл аккаунт на sentry.io и там получил dsn. Сделал проверку работоспособности как указано в [документации](https://docs.sentry.io/platforms/javascript/guides/react/) всё получилось, ошибка попала во вкладку Issues в аккаунте sentry.io. 
Для правильной работы в runit нужно добавить dsn в переменные окружения и должно заработать.