### PR TITLE
Added Copy URL to Profile, Issue #186

### DIFF
--- a/frontend/src/Pages/Profile.jsx
+++ b/frontend/src/Pages/Profile.jsx
@@ -98,11 +98,15 @@ export function Profile() {
                     <span>{t('profile.editProfileButton')}</span>
                   </div>
                 </Button>
-                <Button className={`${classes.button}`}>
+                <Button
+                  className={`${classes.button}`}
+                  onClick={() => {
+                    navigator.clipboard.writeText(window.location.href);
+                  }}
+                >
                   <div>
                     <span>{t('profile.copyProfileButton')} </span>
                   </div>
-                  {/* TODO: add ability to copy user profile link */}
                 </Button>
               </div>
               <Button


### PR DESCRIPTION
Была проблема, что не работает кнопка "Скопировать ссылку" на странице "Профиль".
Проблема решена. Теперь при нажатии на "Скопировать ссылку" URL страницы копируется в буфер обмена.
<img width="333" alt="image" src="https://user-images.githubusercontent.com/107258045/218254508-51d006c9-7b2a-47a6-a1da-0072861c2777.png">
