### PR TITLE
[#248] Fix login validation bug in modals

### DIFF
--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -12,9 +12,9 @@ import { ComparePasswords } from '../validation/compare-passwords';
 
 export class CreateUserDto {
   @IsNotEmpty()
-  @Length(3, 20)
+  @Length(3, 16)
   @IsString()
-  @Matches(/[A-Za-z]/)
+  @Matches(/^[\w\S]*$/)
   @Validate(CheckLogin, {
     message: 'Пользователь уже существует!',
   })

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -15,9 +15,9 @@ import { ComparePasswords } from '../validation/compare-passwords';
 export class UpdateUserDto {
   @IsOptional()
   @IsNotEmpty()
-  @Length(3, 20)
+  @Length(3, 16)
   @IsString()
-  @Matches(/[A-Za-z]/)
+  @Matches(/^[\w\S]*$/)
   @Validate(CheckLogin, {
     message: 'Уже существует!',
   })

--- a/frontend/src/components/Modals/EditProfile.jsx
+++ b/frontend/src/components/Modals/EditProfile.jsx
@@ -30,10 +30,9 @@ function EditProfile() {
     },
     validationSchema: object().shape({
       login: string()
-        .trim()
         .min(3, t('signUp.validation.usernameLength'))
-        .max(20, t('signUp.validation.usernameLength'))
-        .matches(/^[A-Za-z ]*$/, t('signUp.validation.correctUsername'))
+        .max(16, t('signUp.validation.usernameLength'))
+        .matches(/^[\w\S]*$/, t('signUp.validation.correctUsername'))
         .typeError()
         .required(t('signUp.validation.requiredField')),
       email: string()

--- a/frontend/src/components/Modals/SignUp.jsx
+++ b/frontend/src/components/Modals/SignUp.jsx
@@ -21,17 +21,16 @@ function SignUpModal() {
 
   const formik = useFormik({
     initialValues: {
-      name: '',
+      login: '',
       email: '',
       password: '',
       confirmPassword: '',
     },
     validationSchema: object().shape({
-      name: string()
-        .trim()
+      login: string()
         .min(3, t('signUp.validation.usernameLength'))
-        .max(20, t('signUp.validation.usernameLength'))
-        .matches(/^[A-Za-z ]*$/, t('signUp.validation.correctUsername'))
+        .max(16, t('signUp.validation.usernameLength'))
+        .matches(/^[\w\S]*$/, t('signUp.validation.correctUsername'))
         .typeError()
         .required(t('signUp.validation.requiredField')),
       email: string()
@@ -62,7 +61,7 @@ function SignUpModal() {
           console.log(t('errors.unknown'));
           throw err;
         }
-        if (err.response?.status === 409) {
+        if (err.response?.status === 400) {
           setRegFailed(true);
         } else {
           console.log(t('errors.network'));
@@ -113,23 +112,22 @@ function SignUpModal() {
             </Form.Control.Feedback>
           </Form.Group>
           <Form.Group className={classes.formGroup}>
-            <Form.Label htmlFor="name" controlId="name" label="Name">
-              {t('signUp.usernameLabel')}
-            </Form.Label>
+            <Form.Label htmlFor="login">{t('signUp.usernameLabel')}</Form.Label>
             <Form.Control
-              name="name"
-              type="name"
-              autoComplete="username"
-              className={`form-input bg-dark text-white ${classes.signInput}`}
-              required
               onChange={formik.handleChange}
-              value={formik.values.name}
+              value={formik.values.login}
+              onBlur={formik.handleBlur}
+              className={`form-input bg-dark text-white ${classes.signUpInput}`}
+              name="login"
+              id="login"
+              autoComplete="username"
+              required
               isInvalid={
-                (formik.touched.name && formik.errors.name) || regFailed
+                (formik.touched.login && formik.errors.login) || regFailed
               }
             />
             <Form.Control.Feedback type="invalid">
-              {formik.errors.name ? formik.errors.name : regFailed}
+              {formik.errors.login ? formik.errors.login : regFailed}
             </Form.Control.Feedback>
           </Form.Group>
           <Form.Group className={classes.formGroup}>


### PR DESCRIPTION
### [#248 ]
#### Переезд с [#249], пришлось переименовать ветку, чтобы задеплоиться на render.
**Ссылка: https://supersnowsnail-runit.onrender.com/**

Привёл валидацию имени пользователя в модалке редактирования профиля к требуемому виду, аналогично #243.

Заодно пофиксил тот же самый баг в модалке регистрации (которая выпадает, если попробовать поделиться сниппетом, будучи незалогинненым, см. скрин).
![Bug](https://user-images.githubusercontent.com/118603847/234685746-b034c7b7-949f-4f84-be47-79dcb868c322.png)
Бага там было сразу два: собственно, сама валидация, а также то, что у поля для логина был name="name" вместо name="login", из-за чего из формы отсылались неверные данные и сервер возвращал 400 ошибку. По итогу поле логина переделал по аналогии с тем же полем в frontend/src/Pages/SignUp.jsx (кстати, ещё опечатку поправил в catch валидации модалки, там 409 ошибку ловило, поставил 400 по аналогии с frontend/src/Pages/SignUp.jsx).

Ещё, помимо прочего, обнаружил ошибку в валидации на стороне бекэнда (в backend/src/users/dto/create-user.dto.ts и backend/src/users/dto/update-user.dto.ts), причём ранее там были прописаны вообше не валидные RegEx, из-за чего это всё равно ни на что не влияло. На всякий случай исправил RegEx и критерии длины логина на новые, хотя при штатном использовании приложения валидация на фронте всё равно не пропустила бы невалидные данные.
