### PR TITLE
Fix SignUp form hints about the login or email used

### DIFF
--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,19 +1,13 @@
-import {
-  IsEmail,
-  IsString,
-  Length,
-  Matches,
-  Validate,
-} from 'class-validator';
+import { IsEmail, IsString, Length, Matches, Validate } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { CheckEmail } from '../validation/check-email';
 import { CheckLogin } from '../validation/check-login';
 import { ComparePasswords } from '../validation/compare-passwords';
-import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
-  @ApiProperty({ 
+  @ApiProperty({
     minLength: 3,
-    maxLength: 20, 
+    maxLength: 20,
     description: 'Must be unique!',
     example: 'JohnDoe',
     pattern: '/[A-Za-z]/',
@@ -22,22 +16,22 @@ export class CreateUserDto {
   @IsString()
   @Matches(/^[\w\S]*$/)
   @Validate(CheckLogin, {
-    message: 'Пользователь уже существует!',
+    message: 'loginIsUsed',
   })
   login: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     description: 'Must be unique!',
     example: 'jane-doe@mail.ru',
   })
   @IsString()
   @IsEmail()
   @Validate(CheckEmail, {
-    message: 'Пользователь уже существует!',
+    message: 'emailIsUsed',
   })
   email: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     example: 'haew6wae56a45ewgd',
     minLength: 8,
     maxLength: 30,
@@ -46,9 +40,9 @@ export class CreateUserDto {
   @Length(8, 30)
   password: string;
 
-  @ApiProperty({ 
+  @ApiProperty({
     example: 'haew6wae56a45ewgd',
-    description: 'Must be equal with password field!'
+    description: 'Must be equal with password field!',
   })
   @IsString()
   @Validate(ComparePasswords, {

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -32,7 +32,7 @@ const enLocales = {
       passwordLabel: 'Password',
       confirmPasswordLabel: 'Confirm password',
       registerButton: 'Sign up',
-      signUpFailed: 'This user already exists',
+      signUpFailed: 'Sign Up is failed',
       footer: {
         signInHeader: 'Already have an account? ',
         signIn: 'Sign in',
@@ -44,6 +44,8 @@ const enLocales = {
         usernameLength: 'From 3 to 16 characters',
         passwordLength: 'from 8 to 30 characters',
         confirmPassword: 'Passwords must be the same',
+        loginIsUsed: 'This username is already taken',
+        emailIsUsed: 'This email address is already being used',
       },
     },
     remindPass: {

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -32,7 +32,7 @@ const ruLocales = {
       passwordLabel: 'Пароль',
       confirmPasswordLabel: 'Подтвердить пароль',
       registerButton: 'Зарегистрироваться',
-      signUpFailed: 'Такой пользователь уже существует',
+      signUpFailed: 'Невозможно зарегистрировать пользователя',
       footer: {
         signInHeader: 'Уже есть аккаунт? ',
         signIn: 'Войти',
@@ -44,6 +44,8 @@ const ruLocales = {
         usernameLength: 'От 3 до 16 символов',
         passwordLength: 'от 8 до 30 символов',
         confirmPassword: 'Пароли должны совпадать',
+        loginIsUsed: 'Это имя уже занято',
+        emailIsUsed: 'Этот адрес уже зарегистрирован',
       },
     },
     remindPass: {


### PR DESCRIPTION
Теперь при попытке ввести уже занятый логин под полем логина будет отображаться сообщение о недоступности логина (так же, как отображаются сообщения об ошибках валидации). То же самое при использовании уже зарегистрированной почты.

В коде сервера поправлены ответы сервера при невозможности регистрации. Сервер отдает json той же структуры, что и раньше, но в поле `messsage` теперь не массив сообщений об ошибках(`'Пользователь уже существует!'`), а массив с кодами (`'loginIsUsed'`, `'emailIsUsed'`), которые можно обработать на клиенте.