### PR TITLE
Обновлены системные требования в readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Tasks can be discussed in [Telegram](https://t.me/hexletcommunity/12).
 ## System requirements
 
 * node >= 18
-* Yarn
-* Heroku CLI
+* [Yarn 1 (Classic)](https://classic.yarnpkg.com/)
 * PostgreSQL for use in production environments or SQLite for use in local development environments
 
 ## Installation
@@ -37,7 +36,8 @@ make setup
 ```bash
 make start
 ```
-http://localhost:3000
+
+<http://localhost:3000>
 
 ## Run tests
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -22,8 +22,7 @@ Runit — это среда для написания и выполнения к
 ## Системные требования
 
 * node >= 18
-* Yarn
-* Heroku CLI (только для деплоя)
+* [Yarn 1 (Classic)](https://classic.yarnpkg.com/)
 * PostgreSQL для продакшена, либо SQLite для локальной разработки
 
 ## Установка
@@ -37,7 +36,8 @@ make setup
 ```bash
 make start
 ```
-http://localhost:3000
+
+<http://localhost:3000>
 
 ## Запуск тестов
 
@@ -88,8 +88,8 @@ make test-e2e
 
 ---
 
-[![© ООО “Хекслет Рус” logo](https://raw.githubusercontent.com/Hexlet/assets/master/images/hexlet_logo128.png)](https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=hexlet-editor)
+[![© ООО «Хекслет Рус» logo](https://raw.githubusercontent.com/Hexlet/assets/master/images/hexlet_logo128.png)](https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=hexlet-editor)
 
-Этот репозиторий создается и поддерживается командой и сообществом © ООО “Хекслет Рус”, образовательный проект. [Подробнее о © ООО “Хекслет Рус”](https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=hexlet-editor).
+Этот репозиторий создается и поддерживается командой и сообществом © ООО «Хекслет Рус», образовательный проект. [Подробнее о © ООО «Хекслет Рус»](https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=hexlet-editor).
 
 См. самых активных участников на [hexlet-friends](https://friends.hexlet.io/).


### PR DESCRIPTION
1. Добавил ссылку на Yarn 1 (Classic), чтобы было понятно, что в проекте используется именно эта версия, а не 2+.
2. Убрал Heroku CLI из системных требований (так как в тексте ниже приводится инструкция для деплоя на render.com).