### PR TITLE
Fix: #287 Show Snippet Unavailable Dialog and navigate user to home page if snippet has been deleted

### DIFF
--- a/frontend/src/components/Modals/Modal.jsx
+++ b/frontend/src/components/Modals/Modal.jsx
@@ -21,7 +21,7 @@ const modals = {
   confirmDelete: ConfirmationModal,
   editProfile: EditProfile,
   changePassword: ChangePassword,
-  snippetUnavailable: SnippetUnavailable,
+  snippetUnavailable: SnippetUnavailable, // #TODO: Remove this modal once proper re-direct is configured on the backend
 };
 
 function ModalWindow() {

--- a/frontend/src/components/Modals/Modal.jsx
+++ b/frontend/src/components/Modals/Modal.jsx
@@ -9,6 +9,7 @@ import RenameRepl from './RenameRepl.jsx';
 import ConfirmationModal from './Confirmation.jsx';
 import EditProfile from './EditProfile.jsx';
 import ChangePassword from './ChangePassword.jsx';
+import SnippetUnavailable from './SnippetUnavailable.jsx';
 
 const modals = {
   gettingInfo: InfoModal,
@@ -20,6 +21,7 @@ const modals = {
   confirmDelete: ConfirmationModal,
   editProfile: EditProfile,
   changePassword: ChangePassword,
+  snippetUnavailable: SnippetUnavailable,
 };
 
 function ModalWindow() {

--- a/frontend/src/components/Modals/SnippetUnavailable.jsx
+++ b/frontend/src/components/Modals/SnippetUnavailable.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Button, Modal } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { actions as modalActions } from '../../slices/modalSlice.js';
+
+function SnippetUnavailable() {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  const navigate = useNavigate();
+  const handleCloseDialogAndNavigate = () => {
+    navigate('/');
+    dispatch(modalActions.closeModal());
+  };
+
+  return (
+    <Modal animation centered onHide={handleCloseDialogAndNavigate} show>
+      <Modal.Header
+        closeButton
+        closeVariant="white"
+        className="border-bottom-0 bg-dark"
+      />
+
+      <Modal.Body className="bg-dark text-white">
+        <div className="d-flex flex-column align-items-center">
+          <h5 className="text-center">{t('modals.snippetUnavailable')}</h5>
+          <Button
+            className="align-self-end btn btn-primary"
+            onClick={handleCloseDialogAndNavigate}
+          >
+            Ok
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+export default SnippetUnavailable;

--- a/frontend/src/components/Modals/SnippetUnavailable.jsx
+++ b/frontend/src/components/Modals/SnippetUnavailable.jsx
@@ -1,3 +1,4 @@
+// #TODO: remove this file when redirect to 404 added
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/SnippetButton/index.jsx
+++ b/frontend/src/components/SnippetButton/index.jsx
@@ -28,6 +28,7 @@ export const SnippetButton = memo(() => {
         const response = await snippetsApi.getSnippetDataByViewParams(
           snippetParams,
         );
+        // #TODO: remove check once redirect to 404 is configured
         if (response.length === 0) {
           dispatch(modalActions.openModal({ type: 'snippetUnavailable' }));
         }

--- a/frontend/src/components/SnippetButton/index.jsx
+++ b/frontend/src/components/SnippetButton/index.jsx
@@ -25,7 +25,12 @@ export const SnippetButton = memo(() => {
   useEffect(() => {
     const getSnippetData = async () => {
       if (hasViewSnippetParams) {
-        const response = await snippetsApi.getSnippetDataByViewParams(snippetParams);
+        const response = await snippetsApi.getSnippetDataByViewParams(
+          snippetParams,
+        );
+        if (response.length === 0) {
+          dispatch(modalActions.openModal({ type: 'snippetUnavailable' }));
+        }
         const { id, name } = response;
         setSnippetData((state) => ({ ...state, id, name }));
       }
@@ -59,14 +64,8 @@ export const SnippetButton = memo(() => {
         item: {
           name: snippetData?.name,
           id: snippetData?.id,
-          link: snippetsApi.genViewSnippetLink(
-            params.login,
-            params.slug,
-          ),
-          embedLink: snippetsApi.genEmbedSnippetLink(
-            params.login,
-            params.slug,
-          ),
+          link: snippetsApi.genViewSnippetLink(params.login, params.slug),
+          embedLink: snippetsApi.genEmbedSnippetLink(params.login, params.slug),
         },
       }),
     );

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -33,7 +33,7 @@ const enLocales = {
       confirmPasswordLabel: 'Confirm password',
       registerButton: 'Sign up',
       footer: {
-        signUpFailed: 'Sign Up is failed',
+        signUpFailed: 'Sign Up is failed', // #TODO: remove after 404 is configured
         signInHeader: 'Already have an account? ',
         signIn: 'Sign in',
       },
@@ -165,7 +165,7 @@ const enLocales = {
         snippetEmbedLabel: 'Snippet code for insertion',
       },
     },
-    snippetUnavailable: 'Snippet is unavailable or has been deleted by user',
+    snippetUnavailable: 'Snippet is unavailable or has been deleted by user', // #TODO: remove after 404 is configured
     saveHeader: 'Save to share.',
     newSnippetName: 'Snippet Name',
     signInButton: 'Sign in',

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -32,8 +32,8 @@ const enLocales = {
       passwordLabel: 'Password',
       confirmPasswordLabel: 'Confirm password',
       registerButton: 'Sign up',
-      signUpFailed: 'Sign Up is failed',
       footer: {
+        signUpFailed: 'Sign Up is failed',
         signInHeader: 'Already have an account? ',
         signIn: 'Sign in',
       },
@@ -165,6 +165,7 @@ const enLocales = {
         snippetEmbedLabel: 'Snippet code for insertion',
       },
     },
+    snippetUnavailable: 'Snippet is unavailable or has been deleted by user',
     saveHeader: 'Save to share.',
     newSnippetName: 'Snippet Name',
     signInButton: 'Sign in',

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -178,6 +178,7 @@ const ruLocales = {
         confirmNewPassword: 'Подтвердите новый пароль',
         wrongPassword: 'Неверный пароль',
       },
+      snippetUnavailable: 'Сниппет недоступен, или был удалён пользователем',
       saveHeader: 'Сохраните, чтобы поделиться.',
       newSnippetName: 'Название сниппета',
       signInButton: 'Войти',

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -178,7 +178,7 @@ const ruLocales = {
         confirmNewPassword: 'Подтвердите новый пароль',
         wrongPassword: 'Неверный пароль',
       },
-      snippetUnavailable: 'Сниппет недоступен, или был удалён пользователем',
+      snippetUnavailable: 'Сниппет недоступен, или был удалён пользователем', // #TODO: remove after 404 is configured
       saveHeader: 'Сохраните, чтобы поделиться.',
       newSnippetName: 'Название сниппета',
       signInButton: 'Войти',


### PR DESCRIPTION
Этот ПР относится к #287 

Пока что сделал заглушку в виде модалки с надписью что сниппет недоступен или удалён после её закрытия пользователя редиректит на домой. В идеале должен быть ответ с сервера с соответствующим кодом чтобы можно было использовать его для модалки или редеректа. 

<img width="1191" alt="Screenshot 2023-07-12 at 15 59 01" src="https://github.com/hexlet-rus/runit/assets/64642760/e98da104-4234-4eb9-82ec-78344f141d1b">


