### PR TITLE
#303 http to https redirect

### DIFF
--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -166,7 +166,7 @@ const enLocales = {
         snippetEmbedLabel: 'Snippet code for insertion',
       },
       alertGithubHeader: 'Login error',
-      redirectButton: 'Login page'
+      redirectButton: 'Login page',
     },
     saveHeader: 'Save to share.',
     newSnippetName: 'Snippet Name',

--- a/static.json
+++ b/static.json
@@ -1,0 +1,3 @@
+{
+    "https_only": true
+}


### PR DESCRIPTION
Погуглил и, кажется, чтобы heroku начал делать redirect с http к https, ему об этом надо сказать, поэтому добавил файлик static.json с полем https_only: true