### PR TITLE
Fix node_env when tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ db-generate:
 	make -C backend db-generate
 
 start:
-	yarn run npm-run-all start
+	yarn run start:dev
 
 start-prod:
 	make -C backend start-prod

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "start": "PORT=5001 nest start",
     "typeorm": "typeorm-ts-node-commonjs",
     "start:debug": "NODE_ENV=development PORT=5001 nest start --debug --watch",
+    "start:test": "NODE_ENV=test PORT=5001 nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint-fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "build:frontend": "DISABLE_ESLINT_PLUGIN=true yarn workspace frontend run build",
     "build": "npm-run-all --parallel build:*",
     "production": "yarn workspace backend run start:prod",
-    "start:backend": "yarn workspace backend run start:debug",
+    "start:backend:dev": "yarn workspace backend run start:debug",
+    "start:backend:test": "yarn workspace backend run start:test",
     "start:frontend": "yarn workspace frontend run start",
-    "start": "npm-run-all --parallel start:*",
-    "test": "playwright test --trace on" 
+    "start:dev": "npm-run-all --parallel start:backend:dev start:frontend",
+    "start:test": "npm-run-all --parallel start:backend:test start:frontend",
+    "test": "playwright test --trace on"
   },
   "repository": {
     "type": "git",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 5000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -88,7 +88,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run start',
+    command: 'yarn run start:test',
     port: 3000,
     reuseExistingServer: !process.env.CI,
     env: {


### PR DESCRIPTION
Попытался сделать, чтобы playwright для E2E-тестирования запускал сервер не в окружении `NODE_ENV=development`, а в `NODE_ENV=test`, чтобы он не писал в БД (с этой опцией сервер хранит БД в памяти). См. [case 'test':](https://github.com/faciledictu/runit/blob/faac35c28790e3b2593657fd1e14f6d7695563f6/backend/src/config/data-source.config.ts#L31)

Теперь для добавил команду `yarn run start:test`, однако наблюдается ошибка.

В окружении "NODE_ENV=test" какие-то проблемы с сохранением сессии. То есть пользователь логинится, а потом ничего не может сделать (типа создать сниппет или даже разлогиниться), потому что сервер его не авторизует больше. Если этой командой запустить деплой, то будет понятно, о чем я.