### PR TITLE
Fix GitHub OAuth button

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -88,6 +88,6 @@ export class AuthService {
     const token = this.jwtService.sign(payload);
     response.cookie('access_token', token);
 
-    return response.redirect('/profile/snippets');
+    return response.redirect('/profile');
   }
 }

--- a/frontend/src/components/Forms/GithubSignInButton.jsx
+++ b/frontend/src/components/Forms/GithubSignInButton.jsx
@@ -1,16 +1,25 @@
-import Button from 'react-bootstrap/Button';
-import { Github } from 'react-bootstrap-icons';
 import { useTranslation } from 'react-i18next';
 
-function GithubButton() {
+import { Github } from 'react-bootstrap-icons';
+import Button from 'react-bootstrap/Button';
+
+import routes from '../../routes.js';
+
+const OAUTH_LINK = new URL(routes.oAuthPath(), window.location.origin);
+
+if (process.env.NODE_ENV !== 'production') {
+  OAUTH_LINK.port = '5001';
+}
+
+function GithubSignInButton() {
   const { t } = useTranslation();
 
   return (
-    <Button variant="outline-secondary">
+    <Button as="a" href={OAUTH_LINK.toString()} variant="outline-secondary">
       <Github className="bi me-1" />
       {t('formActions.withGithub')}
     </Button>
   );
 }
 
-export default GithubButton;
+export default GithubSignInButton;


### PR DESCRIPTION
После обновления дизайна форм входа и регистрации при нажатии на кнопку входа через Гитхаб ничего не происходило
1. Переделал `button` в `a` Добавил ссылку на авторизацию.
2. Обновил редирект на сервере.

По второму пункту посоветуйте (отдельным коммитом сделал). Ссылка-редирект там была захардкодена и сейчас тоже осталось. Может как-то можно сделать, чтобы фронт уведомлял бэк, куда перебрасывать юзера?
При логине с формы логина перебрасывать на профиль — это ок. Но у нас есть сценарий, когда юзер регистрируется при просмотре сниппета через модалку. Там бы его перебрасывать назад на этот сниппет. А его перебросят на профиль — это не ок.