### PR TITLE
[#379] added a space-symbol to validationSchemas.js/snippetName

### DIFF
--- a/frontend/src/utils/validationSchemas.js
+++ b/frontend/src/utils/validationSchemas.js
@@ -49,4 +49,4 @@ export const snippetName = () =>
   string()
     .required('errors.validation.requiredField')
     .max(SNIPPET_NAME_MAX_LENGTH, 'errors.validation.snippetNameMaxLength')
-    .matches(/^[a-zA-Z0-9._-]*$/, 'errors.validation.singleWord');
+    .matches(/^[a-zA-Z 0-9._-]*$/, 'errors.validation.singleWord');


### PR DESCRIPTION
Пробельный символ был не разрешен для имени сниппета.

Было:
<img width="464" alt="snippet_name_было" src="https://github.com/hexlet-rus/runit/assets/108113888/fe8ff739-26aa-411e-b302-c3f77ecc9735">
Стало:
<img width="489" alt="snippet_name_стало" src="https://github.com/hexlet-rus/runit/assets/108113888/df73d825-5308-4784-8135-35a7d84dce32">
