### PR TITLE
#401 deleted php and python from supported-languages

### DIFF
--- a/frontend/src/slices/languagesSlice.js
+++ b/frontend/src/slices/languagesSlice.js
@@ -4,7 +4,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const slice = createSlice({
   name: 'languages',
   initialState: {
-    supportedLanguages: ['javascript', 'php', 'python', 'html'],
+    supportedLanguages: ['javascript', 'html'],
     currentLanguage: 'javascript',
   },
   reducers: {


### PR DESCRIPTION
убрала в languagesSlice.js из state.supportedLanguages - php, python.

было: 4 поддерживаемых языка

<img width="397" alt="Снимок экрана 2023-11-20 в 15 12 01" src="https://github.com/hexlet-rus/runit/assets/108113888/4bed824c-580d-46be-a101-d70cabc82b25">

стало: 2 поддерживаемых языка

<img width="383" alt="Снимок экрана 2023-11-20 в 15 11 33" src="https://github.com/hexlet-rus/runit/assets/108113888/98ce38aa-7857-4a97-bdf3-b748e7b93723">
