### PR TITLE
[#407] add scss selector for feedback tooltip

### DIFF
--- a/frontend/src/assets/stylesheets/toolbar.scss
+++ b/frontend/src/assets/stylesheets/toolbar.scss
@@ -9,4 +9,8 @@
     line-height: 1;
     font-size: calc(#{$font-size-base} * 1.25);
   }
+  .toolbar-feedback {
+    display: block;
+    min-width: 150px;
+  }
 }

--- a/frontend/src/pages/snippet/FileToolbar.jsx
+++ b/frontend/src/pages/snippet/FileToolbar.jsx
@@ -91,7 +91,7 @@ function SnippetName({ snippet }) {
             ref={inputRef}
             as={AutowidthInput}
             autoComplete="off"
-            className="transition-padding w-auto"
+            className="transition-padding"
             id="name"
             isInvalid={!!formik.errors.name}
             maxLength={30}
@@ -103,7 +103,7 @@ function SnippetName({ snippet }) {
             value={formik.values.name}
           />
           <Form.Control.Feedback
-            className={formik.errors.name && 'd-block'}
+            className={formik.errors.name && 'toolbar-feedback'}
             tooltip
             type="invalid"
           >


### PR DESCRIPTION
Убрал класс у инпута, добавил для фидбека чтобы снова воссоединить карандаш с названием сниппета 
<img width="40" alt="Снимок экрана 2023-10-25 в 09 56 18" src="https://github.com/hexlet-rus/runit/assets/115660566/f12c163a-7535-4cf6-ae5e-4277e8f37103">

fixes #407 