### PR TITLE
#410 changed --bs-accordion-active-color to white

### DIFF
--- a/frontend/src/pages/about/Faq.module.css
+++ b/frontend/src/pages/about/Faq.module.css
@@ -2,6 +2,7 @@
   --bs-accordion-bg: none;
   --bs-accordion-color: white;
   --bs-accordion-btn-color: white;
+  --bs-accordion-active-color: white;
   --bs-accordion-icon-color: #fff;
   --bs-accordion-border-width: 0px;
   margin-left: -1.3rem;
@@ -21,11 +22,10 @@
 }
 :global(.accordion-button:not(.collapsed)::before) {
   transform: var(--bs-accordion-btn-icon-transform);
-  background-image: var(--bs-accordion-btn-active-icon);
 }
 
 :global(.accordion-button::before) {
-  content: '';
+  content: "";
   flex-shrink: 0;
   width: var(--bs-accordion-btn-icon-width);
   height: var(--bs-accordion-btn-icon-width);


### PR DESCRIPTION
FAQ: при открытии аккордеона цвет header менялся на active-color. Я перезаписала этот active-color на white и убрала замену цвета before:иконки. 

Было: 
<img width="954" alt="before" src="https://github.com/hexlet-rus/runit/assets/108113888/b6855ed0-3d34-42ac-ac28-a19336ea45f6">

Стало:
<img width="750" alt="after" src="https://github.com/hexlet-rus/runit/assets/108113888/4400dc6b-0664-4131-82c5-56d13400cf5e">
