### PR TITLE
fixed display of errors when user change account data

### DIFF
--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -26,7 +26,7 @@ export class UpdateUserDto {
   @IsString()
   @Matches(/^[\w\S]*$/)
   @Validate(CheckUsername, {
-    message: 'Уже существует!',
+    message: 'usernameIsUsed',
   })
   username?: string;
 
@@ -39,7 +39,7 @@ export class UpdateUserDto {
   @IsString()
   @IsEmail()
   @Validate(CheckEmail, {
-    message: 'Уже существует!',
+    message: 'emailIsUsed',
   })
   email?: string;
 

--- a/frontend/src/components/Forms/UpdateAccountForm.jsx
+++ b/frontend/src/components/Forms/UpdateAccountForm.jsx
@@ -32,8 +32,10 @@ function UpdateAccountForm() {
     username: userInfo.username,
     email: toUnicode(userInfo.email),
   };
+
   const formik = useFormik({
     initialValues,
+    validateOnBlur: false,
     validationSchema,
     onSubmit: async (values, actions) => {
       setFormState(initialFormState);
@@ -51,8 +53,8 @@ function UpdateAccountForm() {
         });
         actions.resetForm({ values });
       } catch (err) {
-        formik.resetForm();
         if (!err.isAxiosError) {
+          formik.resetForm();
           setFormState({
             state: 'failed',
             message: 'errors.unknown',
@@ -63,7 +65,8 @@ function UpdateAccountForm() {
           err.response?.status === 400 &&
           Array.isArray(err.response?.data?.errs?.message)
         ) {
-          err.response.data.errs.message.forEach((e) => {
+          const errResponseMessages = err.response.data.errs.message;
+          errResponseMessages.forEach((e) => {
             switch (e) {
               case 'usernameIsUsed':
                 actions.setFieldError(


### PR DESCRIPTION
Ошибки обновления пользовательских данных в личном кабинете теперь отображаются. 

деплой: https://heaven-tonight-runit-account-form.onrender.com

Можно зайти под (чтобы не регаться): 
test@mail.ru 
ert645qw

А данные ЛК менять на:
test2
test2@mail.ru

