### PR TITLE
FIX BUG: landing header

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -164,7 +164,10 @@
       "second": "the application"
     },
     "fast": "The free online code editor Run IT will allow you to do this quickly and without fussing with settings",
-    "fastIDE": "Instant IDE",
+    "fastIDE": {
+      "first": "Instant",
+      "second": "IDE"
+    },
     "freeProject": "Free Hexlet Project",
     "inBrowser": "The editor runs entirely in the browser, so you can start coding in seconds",
     "modern": "In modern web development, you need to constantly keep up with the latest news, and even better - to try out new products in real-world",

--- a/frontend/src/pages/landing/index.jsx
+++ b/frontend/src/pages/landing/index.jsx
@@ -46,7 +46,7 @@ function Landing() {
             <h1
               className={`${classes.colorPrimary} text-center fw-bold mb-0 mt-sm-5 display-1`}
             >
-              {t('landing.fastIDE')}
+              {t('landing.fastIDE.first')} {t('landing.fastIDE.second')}
             </h1>
           </Row>
           <Row>


### PR DESCRIPTION
После мержа нового лэндинга, в котором изменился [locales/ru](https://vk.com/away.php?utf=1&to=https%3A%2F%2Fgithub.com%2Fbobronaud%2Frunit%2Fcommit%2Fd8eeb63584872096ae5f9fb2a2482ca098cff4ab%23diff-1b1a51fe9466ee16b644fc148d1f09fd766e1bb7dc73e0357cb83c44200b40e7L167) приходит объект вместо [ожидаемой строки](https://vk.com/away.php?utf=1&to=https%3A%2F%2Fgithub.com%2Fbobronaud%2Frunit%2Fblob%2Fmain%2Ffrontend%2Fsrc%2Fpages%2Flanding%2Findex.jsx%23L49)

Собственно я это дело пофиксил и для консистентности изменил [locales/en](https://vk.com/away.php?utf=1&to=https%3A%2F%2Fgithub.com%2Fbobronaud%2Frunit%2Fblob%2Fmain%2Ffrontend%2Fsrc%2Flocales%2Fen.json%23L167)

Render деплой: https://bobronaud-runit.onrender.com/

Как выглядит баг: <img width="1052" alt="image" src="https://github.com/hexlet-rus/runit/assets/89943183/52183cb1-5c8b-47d9-be82-a250ccff3499">