### PR TITLE
closed #365

### DIFF
--- a/frontend/src/pages/about/Faq.jsx
+++ b/frontend/src/pages/about/Faq.jsx
@@ -6,7 +6,7 @@ export function Faq() {
   const { t } = useTranslation();
   return (
     <Row>
-      <h2 className="text-center h2 fw-bold mb-0 text-white">{t('faq.faq')}</h2>
+      <h2 className="text-center h2 fw-bold mb-0">{t('faq.faq')}</h2>
       <Accordion className="mt-40" flush>
         <Accordion.Item eventKey="0">
           <Accordion.Header>{t('faq.q0')}</Accordion.Header>

--- a/frontend/src/pages/about/Faq.module.css
+++ b/frontend/src/pages/about/Faq.module.css
@@ -1,9 +1,5 @@
 :global(.accordion) {
   --bs-accordion-bg: none;
-  --bs-accordion-color: white;
-  --bs-accordion-btn-color: white;
-  --bs-accordion-active-color: white;
-  --bs-accordion-icon-color: #fff;
   --bs-accordion-border-width: 0px;
   margin-left: -1.3rem;
 }
@@ -23,9 +19,11 @@
 :global(.accordion-button:not(.collapsed)::before) {
   transform: var(--bs-accordion-btn-icon-transform);
 }
-
 :global(.accordion-button::before) {
-  content: "";
+  content: "^";
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  font-weight: lighter;
   flex-shrink: 0;
   width: var(--bs-accordion-btn-icon-width);
   height: var(--bs-accordion-btn-icon-width);
@@ -33,7 +31,6 @@
   background-size: var(--bs-accordion-btn-icon-width);
   transition: var(--bs-accordion-btn-icon-transition);
   margin-right: 15px;
-  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
 }
 
 :global(.accordion-button::after) {

--- a/frontend/src/pages/about/index.jsx
+++ b/frontend/src/pages/about/index.jsx
@@ -6,7 +6,7 @@ function AboutPage() {
   const { t } = useTranslation();
 
   return (
-    <div className="container-fluid py-5 m-0 bg-dark text-white">
+    <div className="container-fluid py-5 m-0">
       <div className="container">
         <h3>{t('about.pageHeader')}</h3>
         <p>

--- a/frontend/src/pages/landing/index.jsx
+++ b/frontend/src/pages/landing/index.jsx
@@ -34,7 +34,7 @@ function Landing() {
   };
 
   return (
-    <div className="bg-dark text-white fw-normal w-100">
+    <div className="fw-normal w-100">
       <main className="container pb-5">
         <section className="d-flex flex-column flex-grow h-100 py-3 py-md-4 py-lg-5 justify-content-evenly">
           <Row>

--- a/frontend/src/pages/license-agreement/index.jsx
+++ b/frontend/src/pages/license-agreement/index.jsx
@@ -4,7 +4,7 @@ function LicenseAgreement() {
   const { t } = useTranslation();
 
   return (
-    <div className="container-fluid py-5 m-0 bg-dark text-white">
+    <div className="container-fluid py-5 m-0">
       <div className="container my-5">
         <div className="row justify-content-center">
           <div className="col-md-10 col-lg-9">


### PR DESCRIPTION
Пофиксил баг с переключением светлой темы на некоторых страницах.

1. Определения классов "bg-dark и text-white" в компонентах мешало переключению темы.
2. Удалил переназначение цвета css стилей аккордеона, что также мешало для работы светлой темы
3. Svg иконка в аккордеоне подгружалась в фиксированном белом цвете, заменил её на прописной знак "^", чтобы он мог менять цвет при переключении темы.

Render деплой: https://bobronaud-runit.onrender.com/