### PR TITLE
[#407] Update the snippet toolbar view

### DIFF
--- a/frontend/src/assets/stylesheets/application.scss
+++ b/frontend/src/assets/stylesheets/application.scss
@@ -46,6 +46,8 @@ $dropdown-padding-y: 0.25rem;
 
 @import "./max-w";
 
+@import "./min-w";
+
 @import "bootstrap/scss/root";
 @import "bootstrap/scss/reboot";
 

--- a/frontend/src/assets/stylesheets/min-w.scss
+++ b/frontend/src/assets/stylesheets/min-w.scss
@@ -1,0 +1,10 @@
+$utilities: map-merge(
+  $utilities,
+  (
+    "min-width": (
+      property: min-width,
+      class: min-w,
+      values: (150: 9.375rem),
+    ),
+  )
+);

--- a/frontend/src/pages/snippet/FileToolbar.jsx
+++ b/frontend/src/pages/snippet/FileToolbar.jsx
@@ -92,7 +92,7 @@ function SnippetName({ snippet }) {
             ref={inputRef}
             as={AutowidthInput}
             autoComplete="off"
-            className="transition-padding w-auto"
+            className="transition-padding"
             id="name"
             isInvalid={!!formik.errors.name}
             maxLength={30}

--- a/frontend/src/pages/snippet/FileToolbar.jsx
+++ b/frontend/src/pages/snippet/FileToolbar.jsx
@@ -104,7 +104,7 @@ function SnippetName({ snippet }) {
             value={formik.values.name}
           />
           <Form.Control.Feedback
-            className={formik.errors.name && 'd-block'}
+            className={formik.errors.name && 'd-block min-w-150'}
             tooltip
             type="invalid"
           >


### PR DESCRIPTION
fixes https://github.com/hexlet-rus/runit/issues/407
1. Удалил класс у инпута, чтобы 'карандаш' был рядом с именем сниппета.
2. Для тултипа добавлен новый класс, чтобы корректно отображалась предупреждающая ошибка.
Класс для тултипа добавлен как новая утилита utilities API в scss/_utilities.scss, потом можно расширить значения и переиспользовать по необходимости.
 ![toolbar](https://github.com/hexlet-rus/runit/assets/111936841/9d9c78dc-7fba-4507-9f69-3224560d29f4) 
 ![tooltip](https://github.com/hexlet-rus/runit/assets/111936841/6c8faf6f-1376-4cd2-bcc3-799cbe9f24e3)

