### PR TITLE
Fix margins in landing

### DIFF
--- a/frontend/src/pages/landing/Landing.jsx
+++ b/frontend/src/pages/landing/Landing.jsx
@@ -119,7 +119,7 @@ function NewLanding() {
             </Col>
           </Row>
           <Row className="d-lg-inline-flex mb-5 my-lg-5 background-dark">
-            <div className="d-lg-flex py-5 justify-content-between px-5">
+            <div className="d-lg-flex py-5 py-xl-4 py-lg-1 px-lg-1 justify-content-between px-5">
               <Col
                 as="figure"
                 className="col-12 d-flex flex-row gap-4 align-items-center col-lg-3 mb-4 mb-lg-0"

--- a/frontend/src/pages/landing/Landing.jsx
+++ b/frontend/src/pages/landing/Landing.jsx
@@ -118,7 +118,7 @@ function NewLanding() {
               </Button>
             </Col>
           </Row>
-          <Row className="d-lg-inline-flex mb-5 my-lg-5 background-dark">
+          <Row className="d-lg-inline-flex mb-5 my-lg-5 background-dark align-items-center">
             <div className="d-lg-flex py-5 py-xl-4 py-lg-1 px-lg-1 justify-content-between px-5">
               <Col
                 as="figure"

--- a/frontend/src/pages/landing/landing.scss
+++ b/frontend/src/pages/landing/landing.scss
@@ -139,9 +139,6 @@
             z-index: -1;
         }
     }
-    .background-dark {
-        color: black;
-    }
     .possibilities-background {
         position: relative;
         &::before {
@@ -157,5 +154,11 @@
             background-size: 100% 100%;
             z-index: -1;
         }
+    }
+}
+
+@media (max-width: 991px) {
+    .background-dark {
+        color: black;
     }
 }


### PR DESCRIPTION
Исправил отступы внутренние и внешние в секции, где указаны удобства сервиса на лендинге.

Было:
<img width="1109" alt="Снимок экрана 2024-04-11 в 19 26 00" src="https://github.com/hexlet-rus/runit/assets/39225852/0c99f482-d7cf-4ee1-87a0-950e7436885b">
<img width="945" alt="Снимок экрана 2024-04-11 в 19 26 04" src="https://github.com/hexlet-rus/runit/assets/39225852/c7b68721-dbd1-449d-86e5-d8225cf5321b">

Стало:

<img width="1511" alt="Снимок экрана 2024-04-11 в 19 24 39" src="https://github.com/hexlet-rus/runit/assets/39225852/42c59097-a964-4ad6-8f12-e730a18ace51">
<img width="1189" alt="Снимок экрана 2024-04-11 в 19 24 55" src="https://github.com/hexlet-rus/runit/assets/39225852/1b08a073-b60b-442d-ada4-d29af3f95fef">
