### PR TITLE
closed/fix #420

### DIFF
--- a/backend/src/config/mailer.config.ts
+++ b/backend/src/config/mailer.config.ts
@@ -1,13 +1,23 @@
 import { MailerOptionsFactory, MailerOptions } from '@nestjs-modules/mailer';
 import { PugAdapter } from '@nestjs-modules/mailer/dist/adapters/pug.adapter';
 
+const configFromName = (transportUrl) => {
+  const parts = transportUrl.replace('smtp://', '').split(':');
+  const [emailName, otherInfo] = parts;
+  const domain = otherInfo.split('.');
+  const [,domName, dom] = domain;
+
+  return `${emailName}@${domName}.${dom}`
+}
+
 export class MailerConfig implements MailerOptionsFactory {
   /* eslint-disable-next-line class-methods-use-this */
   createMailerOptions(): MailerOptions | Promise<MailerOptions> {
+    const transportUrl = process.env.TRANSPORT_MAILER_URL;
     const options: MailerOptions = {
-      transport: process.env.TRANSPORT_MAILER_URL,
+      transport: transportUrl,
       defaults: {
-        from: '"Run IT" <noreply@runit.hexlet.ru>',
+        from: `"Run IT" <${configFromName(transportUrl)}>`,
       },
       template: {
         dir: `${process.cwd()}/src/users/templates`,
@@ -22,10 +32,9 @@ export class MailerConfig implements MailerOptionsFactory {
       case 'production':
         return options;
       default:
-        // FIXME: use some test transport
         options.transport =
           process.env.TRANSPORT_MAILER_URL ??
-          'smtp://test:test@imap.ethereal.email:587';
+          'smtp://user@example.org:236b45b9-b334-45b2-813b-4fab6308e389@app.debugmail.io:25';
         options.preview = true;
         return options;
     }

--- a/backend/src/config/mailer.config.ts
+++ b/backend/src/config/mailer.config.ts
@@ -17,7 +17,7 @@ export class MailerConfig implements MailerOptionsFactory {
     const options: MailerOptions = {
       transport: transportUrl,
       defaults: {
-        from: `"Run IT" <${configFromName(transportUrl)}>`,
+        from: `"Run IT" <${transportUrl ? configFromName(transportUrl) : "test"}>`,
       },
       template: {
         dir: `${process.cwd()}/src/users/templates`,
@@ -34,7 +34,7 @@ export class MailerConfig implements MailerOptionsFactory {
       default:
         options.transport =
           process.env.TRANSPORT_MAILER_URL ??
-          'smtp://user@example.org:236b45b9-b334-45b2-813b-4fab6308e389@app.debugmail.io:25';
+          'smtp://794dca83-1386-44ea-8f60-60308490a1e2:236b45b9-b334-45b2-813b-4fab6308e389@app.debugmail.io:25';
         options.preview = true;
         return options;
     }


### PR DESCRIPTION
Поправила файл mailer.config.ts : 
1. имя отправителя "from" должно совпадать с реальным отправителем письма - добавила функцию, которая вытаскивает имя из TRANSPORT_MAILER_URL

2. в своём деплое https://loresina-runit.onrender.com/ настроила отправку почты через smtp сервер yandex.ru со своего почтового ящика (данные забираются из env деплоя)

3. тестовый почтовый сервис - DebugMail.io - отправляет письмо по-умолчанию на свой сервис, если TRANSPORT_MAILER_URL в env нет.
Это письмо можно увидель только в личном кабинете DebugMail.io. До конечного получателя письмо не отправляется (это не предусмотрено тестовыми smtp сервисами впринципе).

Тестировала I can't remember the password => reset password
письма точно приходят на mail.ru, gmail.com

Можно попробовать со своими данными.