### PR TITLE
fixed appStatus translation

### DIFF
--- a/frontend/src/components/Loaders/DefaultLoader.jsx
+++ b/frontend/src/components/Loaders/DefaultLoader.jsx
@@ -1,14 +1,14 @@
 import { useTranslation } from 'react-i18next';
 
 function DefaultLoader() {
-  const { t: tAS } = useTranslation('translations', { keyPrefix: 'appStatus' });
+  const { t } = useTranslation();
 
   return (
     <div className="h-100 m-auto d-flex flex-column justify-content-center align-items-center text-secondary">
       <div className="spinner-border" role="status">
-        <span className="visually-hidden">{tAS('loading')}</span>
+        <span className="visually-hidden">{t('appStatus.loading')}</span>
       </div>
-      <p className="pt-3">{tAS('loading')}</p>
+      <p className="pt-3">{t('appStatus.loading')}</p>
     </div>
   );
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -25,7 +25,7 @@
     "secondBackendDevTool": "TypeScript"
   },
   "appStatus": {
-    "loading": "Загрузка"
+    "loading": "Загрузка..."
   },
   "codeTemplates": {
     "javascript": "// Здесь будет код на JavaScript\n",


### PR DESCRIPTION
Исправлен перевод спиннера загрузки по умолчанию. Ранее был текст appStatus.loading, сейчас отображает корректные перевод на 2 языках.

<img width="581" alt="Снимок экрана 2024-06-27 в 15 17 53" src="https://github.com/hexlet-rus/runit/assets/39225852/c4bc45f7-6041-4eb8-94a9-bb96af62fbe7">