### PR TITLE
[#517] fixed the disappearance of the footer link in the en version

### DIFF
--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -129,20 +129,18 @@ function Footer() {
                   {tF('agreement')}
                 </Nav.Link>
               </li>
-              {language === 'ru' && (
-                <li>
-                  <Nav.Link
-                    as={Link}
-                    className={`${classes.footerNavLink} py-1 px-0`}
-                    eventKey="licenseAgreement"
-                    to="/licenseAgreement"
-                  >
-                    <span style={{ paddingRight: '1.25rem' }}>
-                      {tF('licenseAgreement')}
-                    </span>
-                  </Nav.Link>
-                </li>
-              )}
+              <li>
+                <Nav.Link
+                  as={Link}
+                  className={`${classes.footerNavLink} py-1 px-0`}
+                  eventKey="licenseAgreement"
+                  to="/licenseAgreement"
+                >
+                  <span style={{ paddingRight: '1.25rem' }}>
+                    {tF('licenseAgreement')}
+                  </span>
+                </Nav.Link>
+              </li>
               <li>
                 <Nav.Link
                   as="a"

--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -6,10 +6,9 @@ import { ReactComponent as Vk } from '../../assets/images/icons/vk.svg';
 import classes from './index.module.css';
 
 function Footer() {
-  const { t: tF, i18n } = useTranslation('translation', {
+  const { t: tF } = useTranslation('translation', {
     keyPrefix: 'footer',
   });
-  const { language } = i18n;
 
   return (
     <footer className="bg-dark border-top border-secondary pt-4 pb-5">

--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -135,9 +135,7 @@ function Footer() {
                   eventKey="licenseAgreement"
                   to="/licenseAgreement"
                 >
-                  <span style={{ paddingRight: '1.25rem' }}>
-                    {tF('licenseAgreement')}
-                  </span>
+                  <span>{tF('licenseAgreement')}</span>
                 </Nav.Link>
               </li>
               <li>

--- a/frontend/src/pages/landing/Footer.jsx
+++ b/frontend/src/pages/landing/Footer.jsx
@@ -25,7 +25,6 @@ function Footer() {
   const { t: tLH } = useTranslation('translation', {
     keyPrefix: 'landing.header',
   });
-  const { t: tFAQ } = useTranslation('translation', { keyPrefix: 'faq' });
   const { t: tF } = useTranslation('translation', { keyPrefix: 'footer' });
 
   const theme = document.documentElement.getAttribute('data-bs-theme');


### PR DESCRIPTION
now the link to the Non-Commercial License Agreement is available in both English and Russian versions

![2024-07-11_15-09-03](https://github.com/hexlet-rus/runit/assets/141544836/5770f521-f81b-4935-8eb6-e37377850885)
