### PR TITLE
[#524]: fixed HTML snippet browser background color in dark theme

### DIFF
--- a/frontend/src/pages/snippet/index.jsx
+++ b/frontend/src/pages/snippet/index.jsx
@@ -164,7 +164,7 @@ function SnippetPage() {
         </Panel>
         <ResizeHandler direction={direction} />
         <Panel
-          className="bg-body rounded-3 overflow-hidden"
+          className="bg-white rounded-3 overflow-hidden"
           collapsible
           minSize={10}
         >


### PR DESCRIPTION
In the HTML snippet, when switching to the dark theme, the browser background now remains white instead of becoming dark. Video below for reference.

https://github.com/user-attachments/assets/9099d6e5-bfc2-4c12-8f98-00d257b92950

