### PR TITLE
[#530]: Profile avatar is now either Github profile picture, or capitalized first letter of username

### DIFF
--- a/frontend/src/components/Avatar/index.jsx
+++ b/frontend/src/components/Avatar/index.jsx
@@ -25,11 +25,12 @@ function Avatar({ username }) {
           style={{
             fontSize: '20px',
             fontWeight: 300,
-            letterSpacing: '-2px',
+            // letterSpacing: '-2px',
             pointerEvents: 'none',
           }}
-          x="20%"
-          y="50%"
+          x="50%"
+          y="52%"
+          textAnchor="middle"
         >
           {username}
         </text>

--- a/frontend/src/components/Avatar/index.jsx
+++ b/frontend/src/components/Avatar/index.jsx
@@ -25,7 +25,6 @@ function Avatar({ username }) {
           style={{
             fontSize: '20px',
             fontWeight: 300,
-            // letterSpacing: '-2px',
             pointerEvents: 'none',
           }}
           x="50%"

--- a/frontend/src/components/Avatar/index.jsx
+++ b/frontend/src/components/Avatar/index.jsx
@@ -27,9 +27,9 @@ function Avatar({ username }) {
             fontWeight: 300,
             pointerEvents: 'none',
           }}
+          textAnchor="middle"
           x="50%"
           y="52%"
-          textAnchor="middle"
         >
           {username}
         </text>

--- a/frontend/src/components/Navigation/UserMenu.jsx
+++ b/frontend/src/components/Navigation/UserMenu.jsx
@@ -49,9 +49,6 @@ function UserMenu() {
     return string.charAt(0).toUpperCase();
   }
 
-  console.log("Mehdi: ", capitalizeFirstLetter("Mehdi"));
-
-
   return (
     <Dropdown align="end" as="li" title="User Menu">
       <Dropdown.Toggle

--- a/frontend/src/components/Navigation/UserMenu.jsx
+++ b/frontend/src/components/Navigation/UserMenu.jsx
@@ -44,10 +44,10 @@ function UserMenu() {
     imageExists(url).then((exists) => setGithubExists(exists));
   }, [username]);
 
-  //This function takes the first letter of the username and converts it to uppercase
+  // This function takes the first letter of the username and converts it to uppercase
   const capitalizeFirstLetter = (string) => {
     return string.charAt(0).toUpperCase();
-  }
+  };
 
   return (
     <Dropdown align="end" as="li" title="User Menu">
@@ -68,12 +68,9 @@ function UserMenu() {
                 borderRadius: '50%',
               }}
             />
-          )
-            : (
-              <Avatar username={capitalizeFirstLetter(username)} />
-            )}
-
-
+          ) : (
+            <Avatar username={capitalizeFirstLetter(username)} />
+          )}
         </div>
         <span className="visually-hidden">{tPA('header')}</span>
       </Dropdown.Toggle>

--- a/frontend/src/components/Navigation/UserMenu.jsx
+++ b/frontend/src/components/Navigation/UserMenu.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -26,6 +27,31 @@ function UserMenu() {
     dispatch(actions.openModal({ type: 'newSnippet' }));
   };
 
+  // The following code checks if the Github profile picture exists
+  const imageExists = (url) => {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = url;
+    });
+  };
+
+  const [githubImageExists, setGithubExists] = useState(false);
+
+  useEffect(() => {
+    const url = `https://github.com/${username}.png`;
+    imageExists(url).then((exists) => setGithubExists(exists));
+  }, [username]);
+
+  //This function takes the first letter of the username and converts it to uppercase
+  const capitalizeFirstLetter = (string) => {
+    return string.charAt(0).toUpperCase();
+  }
+
+  console.log("Mehdi: ", capitalizeFirstLetter("Mehdi"));
+
+
   return (
     <Dropdown align="end" as="li" title="User Menu">
       <Dropdown.Toggle
@@ -34,7 +60,23 @@ function UserMenu() {
         variant="link"
       >
         <div className="logo-height">
-          <Avatar username={username} />
+          {githubImageExists ? (
+            <img
+              alt="Github Profile"
+              src={`https://github.com/${username}.png`}
+              style={{
+                position: 'relative',
+                width: '32px',
+                height: '32px',
+                borderRadius: '50%',
+              }}
+            />
+          )
+            : (
+              <Avatar username={capitalizeFirstLetter(username)} />
+            )}
+
+
         </div>
         <span className="visually-hidden">{tPA('header')}</span>
       </Dropdown.Toggle>


### PR DESCRIPTION
If the user signs in with **Github**, their profile avatar will automatically become their **GitHub profile picture**, like this screenshot below:

![github profile picture](https://github.com/user-attachments/assets/ce081bd6-0449-45bb-a8bc-5a54cddfb14d)

Otherwise, if the user signed in traditionally, then the first **letter of their username** will be **capitalized** and used as avatar to enhance UX, as show in the screenshot below:

![No github](https://github.com/user-attachments/assets/94e06942-6766-4f1a-9452-53cdbc758910)
