### PR TITLE
[#549]: Correction of translation of the "Confirm" button when switching to English

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -211,6 +211,7 @@
       "title": "Duplicate snippet",
       "snippetName": "Snippet name",
       "message": "To copy snippet you need to be authorized",
+      "save": "Confirm",
       "cancel": "Cancel"
     },
     "attemptDuplicateSnippet": {


### PR DESCRIPTION
Added translation of the "Confirm" button in the form for duplicating the snippet when switching to English