### PR TITLE
[#553] fixed guestMenu localization bug

### DIFF
--- a/frontend/src/components/Forms/SignInForm.jsx
+++ b/frontend/src/components/Forms/SignInForm.jsx
@@ -157,7 +157,7 @@ function SignInForm({ onSuccess = () => null }) {
             {tSI('remindPass')}
           </Link>
           <Button
-            className="flex-fill"
+            className="flex-fill w-50"
             data-disable-with={tSI('signInButton')}
             data-testid="signin-button"
             disabled={formik.isSubmitting}

--- a/frontend/src/components/Navigation/GuestMenu.jsx
+++ b/frontend/src/components/Navigation/GuestMenu.jsx
@@ -14,7 +14,9 @@ function GuestMenu() {
   const { t: tSA } = useTranslation('translation', {
     keyPrefix: 'snippetActions',
   });
-  const { t: tSU } = useTranslation('translation', { keyPrefix: 'signUp' });
+  const { t: tSU } = useTranslation('translation', {
+    keyPrefix: 'profileActions',
+  });
   const dispatch = useDispatch();
 
   const handleNewSnippet = () => {
@@ -50,13 +52,13 @@ function GuestMenu() {
         <Dropdown.Divider />
         <li>
           <Dropdown.Item as={Button} onClick={handleSignInButton}>
-            {tSU('signIn.signInButton')}
+            {tSU('signIn')}
           </Dropdown.Item>
         </li>
         <Dropdown.Divider />
         <li>
           <Dropdown.Item as={Button} onClick={handleRegButton}>
-            {tSU('registerButton')}
+            {tSU('signUp')}
           </Dropdown.Item>
         </li>
       </Dropdown.Menu>


### PR DESCRIPTION
ProfileActionButtons localization for GuestUserMenu fixed.

Additionally, fixed the button display on the Sign-In form, which appeared misaligned in English.

Before:
<img width="474" alt="Снимок экрана 2024-09-20 в 00 11 11" src="https://github.com/user-attachments/assets/71817d59-1297-4621-a4f7-68291b0b1488">

After:

<img width="474" alt="Снимок экрана 2024-09-20 в 00 51 43" src="https://github.com/user-attachments/assets/ac6253df-697d-443d-ad82-80c3ea03a77a">


Deploy: https://mad-chameleon-runit.onrender.com