### PR TITLE
[#542]: Add numbering of copies and tooltips for hovering snippet cards

### DIFF
--- a/frontend/src/pages/profile/SnippetCardWrapper.jsx
+++ b/frontend/src/pages/profile/SnippetCardWrapper.jsx
@@ -1,8 +1,7 @@
 function SnippetCardWrapper({ children }) {
+  const childrenProps = children.props.children;
   const hoverTooltip =
-    children.props.children.length > 1
-      ? children.props.children[0].props.data?.name
-      : '';
+    childrenProps.length > 1 ? childrenProps[0].props.data?.name : '';
   return (
     <div className="snippet-card-wrapper" title={hoverTooltip}>
       {children}

--- a/frontend/src/pages/profile/SnippetCardWrapper.jsx
+++ b/frontend/src/pages/profile/SnippetCardWrapper.jsx
@@ -1,5 +1,13 @@
 function SnippetCardWrapper({ children }) {
-  return <div className="snippet-card-wrapper">{children}</div>;
+  const hoverTooltip =
+    children.props.children.length > 1
+      ? children.props.children[0].props.data?.name
+      : '';
+  return (
+    <div className="snippet-card-wrapper" title={hoverTooltip}>
+      {children}
+    </div>
+  );
 }
 
 export default SnippetCardWrapper;

--- a/frontend/src/utils/genDuplicateSnippetName.js
+++ b/frontend/src/utils/genDuplicateSnippetName.js
@@ -9,18 +9,17 @@ const genDuplicateSnippetName = (fileName) => {
 
   let finalName = '';
   const extension = extensionIndex !== -1 ? fileName.slice(extensionIndex) : '';
+  const conditionalFileName =
+    extensionIndex !== -1 ? fileName.slice(0, extensionIndex) : fileName;
+  const isAlreadyCopy = copyTextIndex !== -1;
+  const increaseCopy = `${fileName.slice(0, dashIndex)}_${existCopyNumber + 1}`;
 
-  if (copyTextIndex !== -1) {
-    if (dashIndex > copyTextIndex) {
-      finalName = `${fileName.slice(0, dashIndex)}_${
-        existCopyNumber + 1
-      }${extension}`;
-    } else if (extensionIndex !== -1) {
-      finalName = `${fileName.slice(0, extensionIndex)}_${1}${extension}`;
-    } else {
-      finalName = `${fileName}_${1}${extension}`;
-    }
-  } else finalName = `${fileName}-copy${extension}`;
+  if (isAlreadyCopy && dashIndex > copyTextIndex) {
+    finalName = `${increaseCopy}${extension}`;
+  } else {
+    finalName = `${conditionalFileName}_${1}${extension}`;
+  }
+  if (!isAlreadyCopy) finalName = `${conditionalFileName}-copy${extension}`;
 
   if (finalName.length >= SNIPPET_NAME_MAX_LENGTH) {
     return finalName.slice(finalName.length - SNIPPET_NAME_MAX_LENGTH);

--- a/frontend/src/utils/genDuplicateSnippetName.js
+++ b/frontend/src/utils/genDuplicateSnippetName.js
@@ -5,7 +5,6 @@ const genDuplicateSnippetName = (fileName) => {
   const copyTextIndex = fileName.lastIndexOf('-copy');
   const dashIndex = fileName.lastIndexOf('_');
   const existCopyNumber = Number(fileName.slice(dashIndex + 1));
-  console.log(copyTextIndex, dashIndex, existCopyNumber, extensionIndex);
 
   let finalName = '';
   const extension = extensionIndex !== -1 ? fileName.slice(extensionIndex) : '';

--- a/frontend/src/utils/genDuplicateSnippetName.js
+++ b/frontend/src/utils/genDuplicateSnippetName.js
@@ -2,19 +2,25 @@ import { SNIPPET_NAME_MAX_LENGTH } from './validationSchemas';
 
 const genDuplicateSnippetName = (fileName) => {
   const extensionIndex = fileName.lastIndexOf('.');
+  const copyTextIndex = fileName.lastIndexOf('-copy');
+  const dashIndex = fileName.lastIndexOf('_');
+  const existCopyNumber = Number(fileName.slice(dashIndex + 1));
+  console.log(copyTextIndex, dashIndex, existCopyNumber, extensionIndex);
 
   let finalName = '';
+  const extension = extensionIndex !== -1 ? fileName.slice(extensionIndex) : '';
 
-  if (extensionIndex === -1) {
-    finalName = `${fileName}-copy`;
-  } else {
-    const [name, extension] = [
-      fileName.slice(0, extensionIndex),
-      fileName.slice(extensionIndex + 1),
-    ];
-
-    finalName = `${name}-copy.${extension}`;
-  }
+  if (copyTextIndex !== -1) {
+    if (dashIndex > copyTextIndex) {
+      finalName = `${fileName.slice(0, dashIndex)}_${
+        existCopyNumber + 1
+      }${extension}`;
+    } else if (extensionIndex !== -1) {
+      finalName = `${fileName.slice(0, extensionIndex)}_${1}${extension}`;
+    } else {
+      finalName = `${fileName}_${1}${extension}`;
+    }
+  } else finalName = `${fileName}-copy${extension}`;
 
   if (finalName.length >= SNIPPET_NAME_MAX_LENGTH) {
     return finalName.slice(finalName.length - SNIPPET_NAME_MAX_LENGTH);


### PR DESCRIPTION
Hi there! 
Fix for #542 
Fix for #541 

Decided to do both parts of the issue since they both significantly improve UX. 

1. Fixed the function of naming created duplicate snippets. Now the function will not duplicate the infinite insertion of “-copy”, and will take into account the number of copies. 
![изображение](https://github.com/user-attachments/assets/ebc94cd3-cb76-4258-887e-f9a703d7ae25)

2. Also I added tooltips for hovering on snippet cards. There is it's looks like
![изображение](https://github.com/user-attachments/assets/14795149-1a39-4b24-b093-ed16ab181329)

