### PR TITLE
[#556]: Fix text visibility in Dark mode on 404 page

### DIFF
--- a/frontend/src/pages/404/index.jsx
+++ b/frontend/src/pages/404/index.jsx
@@ -1,10 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useTernaryDarkMode } from 'usehooks-ts';
 
 function NotFound() {
   const { t: tPNF } = useTranslation('translation', {
     keyPrefix: 'pageNotFound',
   });
+  const { isDarkMode } = useTernaryDarkMode();
+  const paragraphClass = `fs-5 mb-3 ${isDarkMode ? '' : 'text-black '}`;
 
   return (
     <div className="container mb-5">
@@ -19,11 +22,11 @@ function NotFound() {
         </div>
         <div className="col">
           <h1 className="mb-4">{tPNF('title')}</h1>
-          <p className="fs-5 text-black mb-3">{tPNF('whatHappened.title')}</p>
+          <p className={paragraphClass}>{tPNF('whatHappened.title')}</p>
           <p className="mb-4">{tPNF('whatHappened.body')}</p>
-          <p className="fs-5 text-black mb-3">{tPNF('whyHappened.title')}</p>
+          <p className={paragraphClass}>{tPNF('whyHappened.title')}</p>
           <p className="mb-4">{tPNF('whyHappened.body')}</p>
-          <p className="fs-5 text-black mb-3">{tPNF('whatToDo.title')}</p>
+          <p className={paragraphClass}>{tPNF('whatToDo.title')}</p>
           <p className="mb-2">
             {tPNF('whatToDo.body')}
             <Link to="/">{tPNF('whatToDo.returnButton')}</Link>


### PR DESCRIPTION
Hi there, Hexlet team! 
I found the issue #556 and I'm fixing it by myself

The page is looking better now: 
![изображение](https://github.com/user-attachments/assets/9fd0d4ec-db4d-42fc-80d3-d2790a100b0c)
