### PR TITLE
#564 bug at new snippet selection

### DIFF
--- a/frontend/src/components/Modals/NewSnippet.jsx
+++ b/frontend/src/components/Modals/NewSnippet.jsx
@@ -18,16 +18,7 @@ import routes from '../../routes';
 import { useAuth, useSnippets } from '../../hooks';
 import { snippetName } from '../../utils/validationSchemas';
 import { actions as modalActions } from '../../slices/modalSlice.js';
-import JavaScriptIcon from '../../assets/images/icons/javascript.svg';
-import HtmlIcon from '../../assets/images/icons/html.svg';
-import PhpIcon from '../../assets/images/icons/php.svg';
-import PythonIcon from '../../assets/images/icons/python.svg';
-
-const icons = new Map()
-  .set('javascript', JavaScriptIcon)
-  .set('html', HtmlIcon)
-  .set('python', PythonIcon)
-  .set('php', PhpIcon);
+import icons from '../../utils/icons';
 
 const generateGuestUserData = () => {
   const username = `guest_${faker.string.alphanumeric(5)}`;
@@ -170,11 +161,19 @@ function NewSnippet({ handleClose, isOpen }) {
   };
 
   const handleInputLng = (inputValue) => {
-    if (inputValue && inputValue.trim() !== '') {
+    const lowerInput = inputValue.trim().toLowerCase();
+
+    if (lowerInput) {
       const filteredOptions = supportedLanguages.filter((language) =>
-        language.toLowerCase().startsWith(inputValue.toLowerCase()),
+        language.toLowerCase().startsWith(lowerInput),
       );
-      setSelectedLng(filteredOptions.slice(0, 1));
+
+      const selectedLanguage =
+        filteredOptions.find(
+          (language) => language.toLowerCase() === lowerInput,
+        ) || filteredOptions[0];
+
+      setSelectedLng([selectedLanguage]);
 
       if (!once) {
         setOnce(true);

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -193,7 +193,8 @@
     "javascript": "JavaScript",
     "php": "PHP",
     "python": "Python",
-    "html": "HTML"
+    "html": "HTML",
+    "java": "Java"
   },
   "modals": {
     "inDevelopment": {

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -196,7 +196,8 @@
     "javascript": "JavaScript",
     "php": "PHP",
     "python": "Python",
-    "html": "HTML"
+    "html": "HTML",
+    "java": "Java"
   },
   "licAgr": {
     "city": "город Ульяновск",


### PR DESCRIPTION
BUG #564 

- added java language to i18next locales to fix java icon appearance
- fixed handleInputLng() function at NewSnippet.jsx

while testing the code, i've discovered a new bug at modal on new snippet selection:

inside modal we cannot select "java" option because of this block:
```javascript
const filteredOptions = supportedLanguages.filter((language) =>
        language.toLowerCase().startsWith(inputValue.toLowerCase()),
      );
setSelectedLng(filteredOptions.slice(0, 1));
```

when we type "java" the filteredOptions will filter all occurences which starts from "java". It means option "javascript" has been included. Array will become like this:
```javascript
const filteredOptions = ['javascript', 'java'];
// filteredOptions.slice(0, 1) = 'javascript';
setSelectedLng('javascript');
```

at my variant selection work by next case:
```javascript
const filteredOptions = supportedLanguages.filter((language) =>
    language.toLowerCase().startsWith(lowerInput),
);

// select exact match, if non existed then select first
const selectedLanguage =
    filteredOptions.find(
        (language) => language.toLowerCase() === lowerInput,
    ) || filteredOptions[0];

setSelectedLng([selectedLanguage]);
```

https://github.com/user-attachments/assets/1b8bc2ca-76e1-47ad-94f8-3c204fce5ea3


https://github.com/user-attachments/assets/21f3bd9e-9681-4d8f-bc00-e0aae9c74b9e


https://github.com/user-attachments/assets/ade067fb-0e4f-4a4a-9741-70dbb168968a