### PR TITLE
Remove guestUserData from localStorage on GitHubSignInButton click

### DIFF
--- a/frontend/src/components/Forms/GithubSignInButton.jsx
+++ b/frontend/src/components/Forms/GithubSignInButton.jsx
@@ -11,6 +11,10 @@ if (process.env.NODE_ENV !== 'production') {
   OAUTH_LINK.port = '5001';
 }
 
+const handleClick = () => {
+  localStorage.removeItem('guestUserData');
+};
+
 function GithubSignInButton() {
   const { t: tFA, i18n } = useTranslation('translation', {
     keyPrefix: 'formActions',
@@ -21,7 +25,12 @@ function GithubSignInButton() {
   }
 
   return (
-    <Button as="a" href={OAUTH_LINK.toString()} variant="outline-secondary">
+    <Button
+      as="a"
+      href={OAUTH_LINK.toString()}
+      onClick={handleClick}
+      variant="outline-secondary"
+    >
       <Github className="bi me-1" />
       {tFA('withGithub')}
     </Button>


### PR DESCRIPTION
The problem was this: When you click the "Try without registration" button, guest data was added to the browser local storage. Then, when you click the login via github button, the guest data was not deleted from the local storage. And this led to the user menu not being displayed correctly in the navigation bar. I added a handler for clicking the login via github button, which deletes the guest data from the local storage. Perhaps this is not the best solution. If so, please provide comments on how you would like to see the implementation of deleting guest data from the local storage. Perhaps this is an architectural issue and fixing a user as a guest or as an authorized user should be done through the state manager (redux), and not through the browser's local storage. Please clarify.