### PR TITLE
Fix issue #524: исправлено отображение HTML-сниппетов в темной теме

### DIFF
--- a/frontend/src/pages/snippet/index.jsx
+++ b/frontend/src/pages/snippet/index.jsx
@@ -173,12 +173,7 @@ function SnippetPage() {
           minSize={10}
         >
           {currentLanguage === 'html' ? (
-            <div
-              style={{
-                backgroundColor: 'white',
-                height: '100%',
-              }}
-            >
+            <div className="bg-white h-100">
               <HTMLPreview code={code} />
             </div>
           ) : (

--- a/frontend/src/pages/snippet/index.jsx
+++ b/frontend/src/pages/snippet/index.jsx
@@ -173,7 +173,14 @@ function SnippetPage() {
           minSize={10}
         >
           {currentLanguage === 'html' ? (
-            <HTMLPreview code={code} />
+            <div
+              style={{
+                backgroundColor: 'white',
+                height: '100%',
+              }}
+            >
+              <HTMLPreview code={code} />
+            </div>
           ) : (
             <Terminal />
           )}


### PR DESCRIPTION
### #524 
## Исправлено / Fixed:

* ### Фон теперь устанавливается только для HTML-сниппетов, что предотвращает проблемы с видимостью текста при переключении тем / Backgrounds are now only set for HTML snippets, preventing text visibility issues when switching themes

* ### Установлен белый фон для HTML-сниппетов, чтобы текст всегда оставался видимым при переключении между светлой и темной темами / Set a white background for HTML snippets so that the text always remains visible when switching between light and dark themes