### PR TITLE
fix: pop up menu in newSnippet modal

### DIFF
--- a/frontend/src/components/Modals/NewSnippet.jsx
+++ b/frontend/src/components/Modals/NewSnippet.jsx
@@ -196,7 +196,7 @@ function NewSnippet({ handleClose, isOpen }) {
             <Typeahead
               id="template"
               labelKey="template"
-              maxResults={10}
+              maxResults={12}
               onChange={([e]) => handleInputLng(e)}
               options={supportedLanguages}
               renderInput={({ referenceElementRef, ...inputProps }) => {

--- a/frontend/src/components/Modals/NewSnippet.jsx
+++ b/frontend/src/components/Modals/NewSnippet.jsx
@@ -160,7 +160,7 @@ function NewSnippet({ handleClose, isOpen }) {
     setIsLoading(false);
   };
 
-  const handleInputLng = (inputValue) => {
+  const handleInputLng = (inputValue = '') => {
     const lowerInput = inputValue.trim().toLowerCase();
 
     if (lowerInput) {
@@ -196,7 +196,7 @@ function NewSnippet({ handleClose, isOpen }) {
             <Typeahead
               id="template"
               labelKey="template"
-              maxResults={3}
+              maxResults={10}
               onChange={([e]) => handleInputLng(e)}
               options={supportedLanguages}
               renderInput={({ referenceElementRef, ...inputProps }) => {


### PR DESCRIPTION
Доделал [issue #564](https://github.com/hexlet-rus/runit/issues/564) - увеличил количество отображаемых  языков в popup окне. 

В процессе правки обнаружил потенциальный баг:
1.  Заходим в модальное окно по кнопке "Try without registration"  
2. Выбираем язык
3. После этого пытаемся в строке ввода языка поправить, нажимаем либо del либо backspace - сайт падает с белым экраном. Ошибки на прикладываемом видео.

https://github.com/user-attachments/assets/540c3a7f-30a8-4746-81d3-61e4c8af6be3


Баг поправил - в handleInputLng() сделал дефолтное значение для аргумента (пока кроме пустой строки ничего дельного не придумал), чтобы не передавалось undefined.

[деплой](https://ja-ru-runit.onrender.com/)