### PR TITLE
Remove all console.log from backend

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -20,7 +20,6 @@ export const runMigrations = async () => {
   try {
     const migrationsPath = path.join(__dirname, '../../drizzle');
     await migrate(db, { migrationsFolder: migrationsPath });
-    console.log('Migrations completed successfully');
   } catch (error) {
     console.error('Migration failed:', error);
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ const getApp = async () => {
   }
  
 // to do: подключить полноценное логирование (pino-pretty)
-// убрать consol.log с прода
 
   const server = fastify({
   logger: {
@@ -26,10 +25,6 @@ const getApp = async () => {
     ignoreTrailingSlash: true
   },
 });
-
-  console.log('🔍 appRouter type:', typeof appRouter);
-  // console.log('🔍 createContext type:', typeof createContext);
-  console.log('🔍 appRouter procedures:', Object.keys(appRouter._def?.procedures || {}));
 
   server.get('/', async (request, reply) => {
     reply.type('text/html').send(`
@@ -53,8 +48,6 @@ const getApp = async () => {
   });
 
     try {
-    console.log('📡 Registering tRPC plugin...');
-    
     await server.register(fastifyTRPCPlugin, {
       prefix: '/trpc',
       trpcOptions: {
@@ -65,8 +58,6 @@ const getApp = async () => {
         },
       } satisfies FastifyTRPCPluginOptions<AppRouter>['trpcOptions'],
     });
-    
-    console.log('✅ tRPC plugin registered successfully');
   } catch (error) {
     console.error('❌ Failed to register tRPC plugin:', error);
     throw error;

--- a/src/router/snippetRouter.ts
+++ b/src/router/snippetRouter.ts
@@ -39,7 +39,6 @@ export const snippetRouter = router({
 
   getAllSnippets: publicProcedure
     .query(async () => {
-      console.log('getAllSnippets called');
       return await getAllSnippets();
     }),
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,4 @@ app.listen({ port, host }, (err: Error | null, address: string) => {
     console.error('Error starting server:', err);
     process.exit(1);
   }
-  console.log(`Server is running on ${address}`);
-  console.log(`welcome endpoint: ${address}/`);
 });


### PR DESCRIPTION
Removed all "console.log" from backend because server is already writing logs through the Fastify logger.