### PR TITLE
fix(frontend): устранить белый экран при старте (dedupe react-router)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
       icon: true
     }
   })],
+  resolve: {
+    // react-router и react-router-dom должны резолвиться в единственную копию,
+    // иначе Vite пребандлит их отдельно и контекст <Router> не виден хукам,
+    // импортированным из 'react-router' (белый экран на старте). См. #811.
+    dedupe: ['react', 'react-dom', 'react-router', 'react-router-dom'],
+  },
   server: {
     port: 3000,
     open: "/",


### PR DESCRIPTION
## Проблема

При запуске дев-сервера приложение падает в белый экран на лендинге:

```
useNavigate() may be used only in the context of a <Router> component.  (Header.tsx)
```

`useNavigate` импортируется из `react-router`, а `BrowserRouter` — из `react-router-dom`. Vite пребандлит их как две отдельные копии, поэтому контекст `<Router>` не виден хукам из `react-router`, и всё дерево крашится (error boundary нет).

## Фикс

Одна строка в `frontend/vite.config.ts` — `resolve.dedupe` для `react`, `react-dom`, `react-router`, `react-router-dom`, чтобы они резолвились в единственную копию.

Проверено локально: с фиксом лендинг рендерится, без него — белый экран.

Fixes #811