### PR TITLE
feat(frontend): Runit v2 MVP — все экраны нового дизайна на Mantine

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Run IT</title>
+    <title>Runit</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;600;700;800&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/frontend/src/application.tsx
+++ b/frontend/src/application.tsx
@@ -1,23 +1,15 @@
-import { configureStore } from '@reduxjs/toolkit';
-// import * as Sentry from '@sentry/react';
-import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import '@mantine/core/styles.css';
-import '@mantine/notifications/styles.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MantineProvider } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 
 import { createTRPCClient, httpLink } from '@trpc/client';
 import type { AppRouter } from '../../types/router/index';
-import AppRoutes from './AppRoutes';
-import ModalWindow from './components/Modals/index';
-import Toast from './components/Toast/index';
-import AuthProvider from './providers/AuthProvider';
-import SnippetsProvider from './providers/SnippetsProvider';
-import { rootReducer } from './slices/index';
-import { initI18next } from './initI18next';
+import V2App from './v2/App';
 import { TRPCProvider } from './utils/trpc';
+
+// Runit v2 (MVP): новый интерфейс живёт в src/v2/ и является приложением по
+// умолчанию. Легаси-страницы (src/pages/, src/components/) отключены от
+// роутинга, но оставлены в репозитории как справочный материал — их разбор
+// идёт в задачах #814 (JS→TS), #816 (Bootstrap→Mantine), #815 (old-landing).
 
 const makeQueryClient = () =>
   new QueryClient({
@@ -34,47 +26,16 @@ export default async () => {
     links: [
       httpLink({
         url: '/trpc',
-        headers() {
-          const token = localStorage.getItem('token');
-          return token ? { authorization: `Bearer ${token}` } : {};
-        },
       }),
     ],
   });
 
-  await initI18next();
-
-  const store = configureStore({
-    reducer: rootReducer,
-  });
-  // Sentry.init({
-  //   dsn: process.env.REACT_APP_SENTRY_DSN,
-  //   integrations: [new Sentry.BrowserTracing()],
-  //   tracesSampleRate: 1.0,
-  // });
-
   return (
     <QueryClientProvider client={queryClient}>
       <TRPCProvider queryClient={queryClient} trpcClient={trpcClient}>
-        <Provider store={store}>
-          <BrowserRouter
-            future={{
-              v7_relativeSplatPath: true,
-              v7_startTransition: true,
-            }}
-          >
-            <AuthProvider>
-              <SnippetsProvider>
-                <MantineProvider withCssVariables withStaticClasses>
-                  <Notifications />
-                  <AppRoutes />
-                  <ModalWindow />
-                </MantineProvider>
-                <Toast />
-              </SnippetsProvider>
-            </AuthProvider>
-          </BrowserRouter>
-        </Provider>
+        <BrowserRouter>
+          <V2App />
+        </BrowserRouter>
       </TRPCProvider>
     </QueryClientProvider>
   );

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,8 @@
 import ReactDOM from 'react-dom/client';
 
-import './assets/stylesheets/application.scss';
+// Runit v2: лёгкие глобальные стили вместо легаси bootstrap-сборки
+// (application.scss остаётся для справки — см. #816).
+import './v2/global.css';
 import app from './application.tsx';
 
 const run = async () => {

--- a/frontend/src/v2/App.tsx
+++ b/frontend/src/v2/App.tsx
@@ -1,0 +1,54 @@
+import { Suspense, lazy } from 'react';
+import { Route, Routes } from 'react-router-dom';
+import '@mantine/core/styles.css';
+import '@mantine/notifications/styles.css';
+import { Center, Loader, MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
+
+import { v2Theme } from './theme';
+import { SessionProvider } from './session';
+import { AuthModalProvider } from './components/AuthModal';
+
+const Landing = lazy(() => import('./pages/Landing'));
+const Editor = lazy(() => import('./pages/Editor'));
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Share = lazy(() => import('./pages/Share'));
+const Embed = lazy(() => import('./pages/Embed'));
+const Profile = lazy(() => import('./pages/Profile'));
+const Settings = lazy(() => import('./pages/Settings'));
+const Legal = lazy(() => import('./pages/Legal'));
+const NotFound = lazy(() => import('./pages/NotFound'));
+
+function Fallback() {
+  return (
+    <Center h="60vh">
+      <Loader />
+    </Center>
+  );
+}
+
+export default function V2App() {
+  return (
+    <MantineProvider theme={v2Theme} withCssVariables withStaticClasses>
+      <Notifications position="bottom-center" />
+      <SessionProvider>
+        <AuthModalProvider>
+          <Suspense fallback={<Fallback />}>
+            <Routes>
+              <Route index element={<Landing />} />
+              <Route path="/editor" element={<Editor />} />
+              <Route path="/editor/:id" element={<Editor />} />
+              <Route path="/snippets" element={<Dashboard />} />
+              <Route path="/s/:username/:slug" element={<Share />} />
+              <Route path="/embed/:username/:slug" element={<Embed />} />
+              <Route path="/u/:username" element={<Profile />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="/legal" element={<Legal />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
+        </AuthModalProvider>
+      </SessionProvider>
+    </MantineProvider>
+  );
+}

--- a/frontend/src/v2/components/AppFooter.tsx
+++ b/frontend/src/v2/components/AppFooter.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom';
+import { Anchor, Box, Container, Group, Text } from '@mantine/core';
+import { RunitLogo } from './AppHeader';
+
+export default function AppFooter() {
+  return (
+    <Box component="footer" py={28} mt="auto" style={{ borderTop: '1px solid #e9ecef', background: '#fff' }}>
+      <Container size="lg">
+        <Group justify="space-between" wrap="wrap">
+          <Group gap={10}>
+            <RunitLogo size={22} />
+            <Text c="dimmed" fz="sm">
+              © 2026 ООО «Хекслет Рус»
+            </Text>
+          </Group>
+          <Group gap="lg">
+            <Anchor component={Link} to="/" c="dimmed" fz="sm">
+              Возможности
+            </Anchor>
+            <Anchor component={Link} to="/" c="dimmed" fz="sm">
+              Встраивание
+            </Anchor>
+            <Anchor component={Link} to="/legal" c="dimmed" fz="sm">
+              Условия использования
+            </Anchor>
+            <Anchor component={Link} to="/legal?tab=privacy" c="dimmed" fz="sm">
+              Конфиденциальность
+            </Anchor>
+          </Group>
+        </Group>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/v2/components/AppHeader.tsx
+++ b/frontend/src/v2/components/AppHeader.tsx
@@ -1,0 +1,119 @@
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Avatar,
+  Box,
+  Button,
+  Container,
+  Group,
+  Menu,
+  Text,
+  UnstyledButton,
+} from '@mantine/core';
+import { useSession } from '../session';
+import { useAuthModal } from './AuthModal/context';
+
+export function RunitLogo({ size = 28 }: { size?: number }) {
+  return (
+    <Group gap={8} wrap="nowrap">
+      <Box
+        w={size}
+        h={size}
+        style={{
+          borderRadius: 8,
+          background: 'var(--mantine-color-blue-6)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <svg width={size * 0.5} height={size * 0.5} viewBox="0 0 24 24" fill="white">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      </Box>
+      <Text fw={800} fz={size * 0.7} c="dark.9">
+        Runit
+      </Text>
+    </Group>
+  );
+}
+
+export function initialsOf(name: string): string {
+  // TODO(#530, #536): единый компонент аватара-инициалов вместо base64-загрузок.
+  return name
+    .split(/[\s_.-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase())
+    .join('');
+}
+
+export default function AppHeader() {
+  const { user, isGuest, logout } = useSession();
+  const auth = useAuthModal();
+  const navigate = useNavigate();
+
+  return (
+    <Box component="header" py={14} style={{ borderBottom: '1px solid #e9ecef', background: '#fff' }}>
+      <Container size="lg">
+        <Group justify="space-between">
+          <UnstyledButton component={Link} to="/">
+            <RunitLogo />
+          </UnstyledButton>
+
+          <Group gap="sm">
+            {isGuest ? (
+              <>
+                <Button variant="subtle" color="gray" onClick={() => auth.open('login')}>
+                  Войти
+                </Button>
+                <Button onClick={() => auth.open('register')}>Регистрация</Button>
+              </>
+            ) : (
+              <>
+                <Button variant="subtle" color="gray" component={Link} to="/snippets">
+                  Мои сниппеты
+                </Button>
+                <Button component={Link} to="/editor">
+                  Новый сниппет
+                </Button>
+                <Menu position="bottom-end" width={200} radius="md">
+                  <Menu.Target>
+                    <UnstyledButton>
+                      <Avatar color="blue" radius="xl">
+                        {initialsOf(user!.username)}
+                      </Avatar>
+                    </UnstyledButton>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Label>
+                      {user!.username}
+                    </Menu.Label>
+                    <Menu.Item component={Link} to="/snippets">
+                      Мои сниппеты
+                    </Menu.Item>
+                    <Menu.Item component={Link} to={`/u/${user!.username}`}>
+                      Профиль
+                    </Menu.Item>
+                    <Menu.Item component={Link} to="/settings">
+                      Настройки
+                    </Menu.Item>
+                    <Menu.Divider />
+                    <Menu.Item
+                      color="red"
+                      onClick={() => {
+                        logout();
+                        navigate('/');
+                      }}
+                    >
+                      Выйти
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+              </>
+            )}
+          </Group>
+        </Group>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/v2/components/AuthModal/AuthForms.tsx
+++ b/frontend/src/v2/components/AuthModal/AuthForms.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Anchor,
+  Button,
+  CloseButton,
+  Group,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { Link } from 'react-router-dom';
+import { useAuthModal, type AuthMode } from './context';
+import { useSession } from '../../session';
+import { RunitLogo } from '../AppHeader';
+
+const EMAIL_RE = /^\S+@\S+\.\S+$/;
+
+const validateEmail = (value: string) =>
+  EMAIL_RE.test(value.trim()) ? null : 'Введите корректный email';
+
+// TODO(#621): проверка сложности пароля + визуальный индикатор надёжности.
+const validatePassword = (value: string) =>
+  value.length >= 8 ? null : 'Пароль должен быть не короче 8 символов';
+
+const validateUsername = (value: string) =>
+  value.trim().length >= 3 ? null : 'Имя должно быть не короче 3 символов';
+
+const titles: Record<AuthMode, string> = {
+  login: 'Вход в Runit',
+  register: 'Регистрация',
+  reset: 'Сброс пароля',
+};
+
+function FormHeader({ title, onClose }: { title: string; onClose: () => void }) {
+  return (
+    <Group justify="space-between" wrap="nowrap">
+      <Group gap="sm" wrap="nowrap">
+        <RunitLogo size={32} />
+        <Title order={3}>{title}</Title>
+      </Group>
+      <CloseButton aria-label="Закрыть" onClick={onClose} />
+    </Group>
+  );
+}
+
+function LoginForm() {
+  const { setMode, close } = useAuthModal();
+  const { login } = useSession();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm({
+    initialValues: { email: '', password: '' },
+    validate: {
+      email: validateEmail,
+      password: validatePassword,
+    },
+  });
+
+  const handleSubmit = form.onSubmit(async ({ email, password }) => {
+    setError(null);
+    setLoading(true);
+    try {
+      const user = await login(email.trim(), password);
+      close();
+      notifications.show({
+        title: 'С возвращением!',
+        message: `Вы вошли как ${user.username}`,
+        color: 'green',
+      });
+    } catch {
+      setError('Пользователь не найден');
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack gap="md">
+        <FormHeader title={titles.login} onClose={close} />
+        {error && (
+          <Alert color="red" radius="md">
+            {error}
+          </Alert>
+        )}
+        <TextInput
+          label="Электронная почта"
+          placeholder="you@example.com"
+          type="email"
+          autoComplete="email"
+          {...form.getInputProps('email')}
+        />
+        <div>
+          <Group justify="space-between" mb={5}>
+            <Text component="label" htmlFor="login-password" size="sm" fw={500}>
+              Пароль
+            </Text>
+            <Anchor component="button" type="button" size="sm" onClick={() => setMode('reset')}>
+              Забыли пароль?
+            </Anchor>
+          </Group>
+          <PasswordInput
+            id="login-password"
+            placeholder="Ваш пароль"
+            autoComplete="current-password"
+            {...form.getInputProps('password')}
+          />
+        </div>
+        <Button type="submit" size="md" radius="md" fullWidth loading={loading}>
+          Войти
+        </Button>
+        <Text size="sm" c="dimmed" ta="center">
+          Нет аккаунта?{' '}
+          <Anchor component="button" type="button" fw={600} onClick={() => setMode('register')}>
+            Зарегистрироваться
+          </Anchor>
+        </Text>
+      </Stack>
+    </form>
+  );
+}
+
+function RegisterForm() {
+  const { setMode, close } = useAuthModal();
+  const { register } = useSession();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm({
+    initialValues: { username: '', email: '', password: '' },
+    validate: {
+      username: validateUsername,
+      email: validateEmail,
+      password: validatePassword,
+    },
+  });
+
+  const handleSubmit = form.onSubmit(async ({ username, email, password }) => {
+    setError(null);
+    setLoading(true);
+    try {
+      const user = await register(username.trim(), email.trim(), password);
+      close();
+      notifications.show({
+        title: 'Аккаунт создан',
+        message: `Добро пожаловать, ${user.username}!`,
+        color: 'green',
+      });
+    } catch {
+      setError('Не удалось создать аккаунт. Возможно, email уже занят.');
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack gap="md">
+        <FormHeader title={titles.register} onClose={close} />
+        {error && (
+          <Alert color="red" radius="md">
+            {error}
+          </Alert>
+        )}
+        <TextInput
+          label="Имя"
+          placeholder="Как к вам обращаться"
+          autoComplete="username"
+          {...form.getInputProps('username')}
+        />
+        <TextInput
+          label="Электронная почта"
+          placeholder="you@example.com"
+          type="email"
+          autoComplete="email"
+          {...form.getInputProps('email')}
+        />
+        <PasswordInput
+          label="Пароль"
+          placeholder="Минимум 8 символов"
+          autoComplete="new-password"
+          {...form.getInputProps('password')}
+        />
+        <Button type="submit" size="md" radius="md" fullWidth loading={loading}>
+          Создать аккаунт
+        </Button>
+        <Text size="xs" c="dimmed" ta="center">
+          Регистрируясь, вы принимаете{' '}
+          <Anchor component={Link} to="/legal" size="xs" onClick={close}>
+            условия использования
+          </Anchor>
+        </Text>
+        <Text size="sm" c="dimmed" ta="center">
+          Уже есть аккаунт?{' '}
+          <Anchor component="button" type="button" fw={600} onClick={() => setMode('login')}>
+            Войти
+          </Anchor>
+        </Text>
+      </Stack>
+    </form>
+  );
+}
+
+function ResetForm() {
+  const { setMode, close } = useAuthModal();
+  const [loading, setLoading] = useState(false);
+
+  const form = useForm({
+    initialValues: { email: '' },
+    validate: { email: validateEmail },
+  });
+
+  // TODO(#640/#620): реальная отправка письма для сброса пароля на бэкенде.
+  const handleSubmit = form.onSubmit(async () => {
+    setLoading(true);
+    // Имитация запроса, чтобы кнопка показала loading-состояние.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    setLoading(false);
+    close();
+    notifications.show({
+      title: 'Сброс пароля',
+      message: 'Письмо отправлено (заглушка)',
+      color: 'blue',
+    });
+  });
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack gap="md">
+        <FormHeader title={titles.reset} onClose={close} />
+        <Text size="sm" c="dimmed">
+          Укажите почту, привязанную к аккаунту, — пришлём ссылку для сброса пароля.
+        </Text>
+        <TextInput
+          label="Электронная почта"
+          placeholder="you@example.com"
+          type="email"
+          autoComplete="email"
+          {...form.getInputProps('email')}
+        />
+        <Button type="submit" size="md" radius="md" fullWidth loading={loading}>
+          Отправить ссылку
+        </Button>
+        <Anchor
+          component="button"
+          type="button"
+          size="sm"
+          ta="center"
+          onClick={() => setMode('login')}
+        >
+          ← Назад ко входу
+        </Anchor>
+      </Stack>
+    </form>
+  );
+}
+
+export default function AuthForms() {
+  const { mode, opened } = useAuthModal();
+  // Пересоздаём формы при каждом открытии модалки, чтобы сбрасывать значения и ошибки.
+  const [instance, setInstance] = useState(0);
+  useEffect(() => {
+    if (opened) setInstance((n) => n + 1);
+  }, [opened]);
+
+  if (mode === 'register') return <RegisterForm key={`register-${instance}`} />;
+  if (mode === 'reset') return <ResetForm key={`reset-${instance}`} />;
+  return <LoginForm key={`login-${instance}`} />;
+}

--- a/frontend/src/v2/components/AuthModal/context.tsx
+++ b/frontend/src/v2/components/AuthModal/context.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+export type AuthMode = 'login' | 'register' | 'reset';
+
+export type AuthModalContextValue = {
+  open: (mode?: AuthMode) => void;
+  close: () => void;
+  mode: AuthMode;
+  setMode: (mode: AuthMode) => void;
+  opened: boolean;
+};
+
+export const AuthModalContext = createContext<AuthModalContextValue | null>(null);
+
+export function useAuthModal(): AuthModalContextValue {
+  const ctx = useContext(AuthModalContext);
+  if (!ctx) throw new Error('useAuthModal must be used within AuthModalProvider');
+  return ctx;
+}

--- a/frontend/src/v2/components/AuthModal/index.tsx
+++ b/frontend/src/v2/components/AuthModal/index.tsx
@@ -1,0 +1,42 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Modal } from '@mantine/core';
+import { AuthModalContext, type AuthMode } from './context';
+import AuthForms from './AuthForms';
+
+export { useAuthModal } from './context';
+
+export function AuthModalProvider({ children }: { children: ReactNode }) {
+  const [opened, setOpened] = useState(false);
+  const [mode, setMode] = useState<AuthMode>('login');
+
+  const value = useMemo(
+    () => ({
+      opened,
+      mode,
+      setMode,
+      open: (m: AuthMode = 'login') => {
+        setMode(m);
+        setOpened(true);
+      },
+      close: () => setOpened(false),
+    }),
+    [opened, mode],
+  );
+
+  return (
+    <AuthModalContext.Provider value={value}>
+      {children}
+      <Modal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        centered
+        radius="lg"
+        padding="xl"
+        size={420}
+        withCloseButton={false}
+      >
+        <AuthForms />
+      </Modal>
+    </AuthModalContext.Provider>
+  );
+}

--- a/frontend/src/v2/global.css
+++ b/frontend/src/v2/global.css
@@ -1,0 +1,27 @@
+/* Глобальные стили Runit v2 (дизайн: светлый фон, Golos Text, кастомный скроллбар) */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f8f9fa;
+  color: #212529;
+  font-family: 'Golos Text', system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(120, 125, 140, 0.35);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/frontend/src/v2/pages/Dashboard/BulkBar.tsx
+++ b/frontend/src/v2/pages/Dashboard/BulkBar.tsx
@@ -1,0 +1,63 @@
+import { Box, Button, Group, Paper, Text, Tooltip } from '@mantine/core';
+import { editorColors } from '../../theme';
+
+// Тёмная панель массовых действий. Появляется, когда выбран хотя бы один сниппет.
+// TODO(#830): массовое добавление тегов (тегов пока нет в модели данных).
+// TODO(#613): смена видимости (поле видимости появится на сервере).
+
+function DisabledAction({ label, tooltip }: { label: string; tooltip: string }) {
+  return (
+    <Tooltip label={tooltip} withArrow>
+      <Box>
+        <Button
+          size="xs"
+          variant="outline"
+          color="gray"
+          disabled
+          styles={{ root: { borderColor: editorColors.border } }}
+        >
+          {label}
+        </Button>
+      </Box>
+    </Tooltip>
+  );
+}
+
+type Props = {
+  count: number;
+  onClear: () => void;
+};
+
+export default function BulkBar({ count, onClear }: Props) {
+  if (count === 0) return null;
+
+  return (
+    <Paper
+      radius="xl"
+      px="lg"
+      py="xs"
+      shadow="xl"
+      style={{
+        position: 'fixed',
+        bottom: 24,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 200,
+        background: editorColors.bg,
+        border: `1px solid ${editorColors.border}`,
+      }}
+    >
+      <Group gap="md" wrap="nowrap">
+        <Text c={editorColors.text} fz="sm" fw={600} style={{ whiteSpace: 'nowrap' }}>
+          Выбрано: {count}
+        </Text>
+        <DisabledAction label="Добавить тег" tooltip="В разработке (#830)" />
+        <DisabledAction label="Сменить видимость" tooltip="В разработке (#613)" />
+        <DisabledAction label="Удалить" tooltip="В разработке (#830/#613)" />
+        <Button size="xs" variant="subtle" color="gray" onClick={onClear}>
+          Снять
+        </Button>
+      </Group>
+    </Paper>
+  );
+}

--- a/frontend/src/v2/pages/Dashboard/EmptyState.tsx
+++ b/frontend/src/v2/pages/Dashboard/EmptyState.tsx
@@ -1,0 +1,68 @@
+import { Box, Button, Group, Paper, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { langMeta } from '../../theme';
+import { sampleCode } from './lib';
+
+const EXAMPLE_LANGS = ['javascript', 'python', 'php'] as const;
+
+type Props = {
+  onCreateClick: () => void;
+  onCreateExample: (language: string) => void;
+  creating: boolean;
+};
+
+export default function EmptyState({ onCreateClick, onCreateExample, creating }: Props) {
+  return (
+    <Stack align="center" gap="lg" py={64}>
+      <Title order={2} ta="center">
+        Создайте первый сниппет
+      </Title>
+      <Text c="dimmed" ta="center" maw={480}>
+        Пишите, запускайте и делитесь кодом прямо в браузере. Один клик — и у вас есть
+        ссылка, которую можно отправить ученикам или коллегам.
+      </Text>
+      <Button size="md" onClick={onCreateClick}>
+        + Новый сниппет
+      </Button>
+
+      <Group gap="sm" mt="md" w="100%" maw={640} wrap="nowrap">
+        <Box style={{ flex: 1, height: 1, background: '#e9ecef' }} />
+        <Text c="dimmed" fz="xs" fw={700} style={{ letterSpacing: 1, whiteSpace: 'nowrap' }}>
+          ИЛИ НАЧНИТЕ С ПРИМЕРА
+        </Text>
+        <Box style={{ flex: 1, height: 1, background: '#e9ecef' }} />
+      </Group>
+
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md" w="100%" maw={760}>
+        {EXAMPLE_LANGS.map((lang) => {
+          const meta = langMeta[lang];
+          const firstLine = (sampleCode[lang] ?? '').split('\n')[0];
+          return (
+            <Paper
+              key={lang}
+              withBorder
+              radius="lg"
+              p="md"
+              component="button"
+              type="button"
+              disabled={creating}
+              onClick={() => onCreateExample(lang)}
+              style={{
+                cursor: creating ? 'wait' : 'pointer',
+                textAlign: 'left',
+                background: '#fff',
+              }}
+            >
+              <Group gap={8} mb={8}>
+                <Box w={10} h={10} style={{ borderRadius: '50%', background: meta.dot }} />
+                <Text fw={600}>{meta.label}</Text>
+              </Group>
+              <Text c="dimmed" fz="xs" ff="monospace" lineClamp={2}>
+                {firstLine}
+              </Text>
+            </Paper>
+          );
+        })}
+      </SimpleGrid>
+    </Stack>
+  );
+}

--- a/frontend/src/v2/pages/Dashboard/NewSnippetModal.tsx
+++ b/frontend/src/v2/pages/Dashboard/NewSnippetModal.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Group,
+  Modal,
+  SegmentedControl,
+  Select,
+  SimpleGrid,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { langMeta } from '../../theme';
+import { useSession } from '../../session';
+import { useTRPCClient } from '../../../utils/trpc';
+import { sampleCode, SNIPPETS_QUERY_KEY } from './lib';
+
+function FieldLabel({ children }: { children: string }) {
+  return (
+    <Text fz="xs" fw={700} c="dimmed" tt="uppercase" style={{ letterSpacing: 0.8 }}>
+      {children}
+    </Text>
+  );
+}
+
+const VISIBILITY_HINTS: Record<string, string> = {
+  private: 'Виден только вам',
+  link: 'Доступен всем, у кого есть ссылка',
+  public: 'Виден в вашем профиле и в поиске',
+};
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+};
+
+export default function NewSnippetModal({ opened, onClose }: Props) {
+  const trpc = useTRPCClient();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { user } = useSession();
+
+  const [name, setName] = useState('');
+  const [language, setLanguage] = useState('javascript');
+  const [visibility, setVisibility] = useState('link');
+  const [withExample, setWithExample] = useState(true);
+  const [rolling, setRolling] = useState(false);
+
+  const rollName = async () => {
+    setRolling(true);
+    try {
+      const generated = await trpc.snippets.generateSnippetName.query();
+      setName(generated.name);
+    } catch {
+      notifications.show({ message: 'Не удалось сгенерировать имя', color: 'red' });
+    } finally {
+      setRolling(false);
+    }
+  };
+
+  // При открытии — сброс формы и сразу сгенерированное имя, как в макете.
+  useEffect(() => {
+    if (!opened) return;
+    setLanguage('javascript');
+    setVisibility('link');
+    setWithExample(true);
+    setName('');
+    rollName();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened]);
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      trpc.snippets.createSnippet.mutate({
+        name: name.trim(),
+        code: withExample ? (sampleCode[language] ?? '') : '',
+        language,
+        userId: user!.id,
+      }),
+    onSuccess: (created: { id: number }) => {
+      queryClient.invalidateQueries({ queryKey: SNIPPETS_QUERY_KEY });
+      onClose();
+      navigate(`/editor/${created.id}`);
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось создать сниппет', color: 'red' });
+    },
+  });
+
+  // TODO(#641): реальный выбор версии среды исполнения; пока статичное значение.
+  const envOptions =
+    language === 'javascript'
+      ? ['Node.js 20 LTS']
+      : [`${langMeta[language]?.label ?? language} — стандартная среда`];
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Text fw={800} fz="xl">
+          Новый сниппет
+        </Text>
+      }
+      radius="lg"
+      size="lg"
+      centered
+    >
+      <Stack gap="md">
+        <Stack gap={6}>
+          <FieldLabel>Название</FieldLabel>
+          <Group gap="xs" wrap="nowrap">
+            <TextInput
+              value={name}
+              onChange={(e) => setName(e.currentTarget.value)}
+              placeholder="имя-сниппета"
+              style={{ flex: 1 }}
+              data-autofocus
+            />
+            <ActionIcon
+              size="lg"
+              variant="default"
+              radius="md"
+              onClick={rollName}
+              loading={rolling}
+              aria-label="Сгенерировать название"
+            >
+              🎲
+            </ActionIcon>
+          </Group>
+        </Stack>
+
+        <Stack gap={6}>
+          <FieldLabel>Язык</FieldLabel>
+          <SimpleGrid cols={3} spacing="xs">
+            {Object.entries(langMeta).map(([key, meta]) => {
+              const active = key === language;
+              return (
+                <UnstyledButton
+                  key={key}
+                  onClick={() => setLanguage(key)}
+                  px="sm"
+                  py={10}
+                  style={{
+                    border: active
+                      ? '2px solid var(--mantine-color-blue-5)'
+                      : '1px solid #dee2e6',
+                    background: active ? 'var(--mantine-color-blue-0)' : '#fff',
+                    borderRadius: 10,
+                  }}
+                >
+                  <Group gap={8} wrap="nowrap">
+                    <Box
+                      w={10}
+                      h={10}
+                      style={{ borderRadius: '50%', background: meta.dot, flexShrink: 0 }}
+                    />
+                    <Text fz="sm" fw={active ? 700 : 500}>
+                      {meta.label}
+                    </Text>
+                  </Group>
+                </UnstyledButton>
+              );
+            })}
+          </SimpleGrid>
+        </Stack>
+
+        <Stack gap={6}>
+          <FieldLabel>Версия среды</FieldLabel>
+          <Select data={envOptions} value={envOptions[0]} allowDeselect={false} />
+        </Stack>
+
+        <Stack gap={6}>
+          {/* TODO(#828): реальное поле видимости на сервере; пока только визуально. */}
+          <FieldLabel>Видимость</FieldLabel>
+          <SegmentedControl
+            fullWidth
+            value={visibility}
+            onChange={setVisibility}
+            data={[
+              { label: 'Приватный', value: 'private' },
+              { label: 'По ссылке', value: 'link' },
+              { label: 'Публичный', value: 'public' },
+            ]}
+          />
+          <Text c="dimmed" fz="sm">
+            {VISIBILITY_HINTS[visibility]}
+          </Text>
+        </Stack>
+
+        <Group justify="space-between" wrap="nowrap" mt={4}>
+          <Box>
+            <Text fw={600}>Начать с примера кода</Text>
+            <Text c="dimmed" fz="sm">
+              Стартовый пример для выбранного языка вместо пустого файла
+            </Text>
+          </Box>
+          <Switch
+            size="md"
+            checked={withExample}
+            onChange={(e) => setWithExample(e.currentTarget.checked)}
+            aria-label="Начать с примера кода"
+          />
+        </Group>
+
+        <Group justify="flex-end" mt="sm">
+          <Button variant="default" onClick={onClose}>
+            Отмена
+          </Button>
+          <Button
+            onClick={() => createMutation.mutate()}
+            loading={createMutation.isPending}
+            disabled={!name.trim()}
+          >
+            Создать сниппет
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/v2/pages/Dashboard/SnippetCard.tsx
+++ b/frontend/src/v2/pages/Dashboard/SnippetCard.tsx
@@ -1,0 +1,126 @@
+import { Link } from 'react-router-dom';
+import { ActionIcon, Anchor, Box, Checkbox, Group, Menu, Paper, Text } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { langMeta } from '../../theme';
+import { relativeDate, type Snippet } from './lib';
+
+function DotsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <circle cx="5" cy="12" r="2" />
+      <circle cx="12" cy="12" r="2" />
+      <circle cx="19" cy="12" r="2" />
+    </svg>
+  );
+}
+
+type Props = {
+  snippet: Snippet;
+  username: string;
+  selected: boolean;
+  onToggleSelect: () => void;
+  onDelete: () => void;
+};
+
+export default function SnippetCard({
+  snippet,
+  username,
+  selected,
+  onToggleSelect,
+  onDelete,
+}: Props) {
+  const meta = langMeta[snippet.language] ?? {
+    label: snippet.language,
+    dot: '#adb5bd',
+    runnable: false,
+  };
+
+  const copyLink = async () => {
+    const url = `${window.location.origin}/s/${username}/${snippet.slug}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      notifications.show({ message: 'Ссылка скопирована', color: 'blue' });
+    } catch {
+      notifications.show({ message: `Не удалось скопировать: ${url}`, color: 'red' });
+    }
+  };
+
+  const handleDelete = () => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(`Удалить сниппет «${snippet.name}»? Это действие необратимо.`)) {
+      onDelete();
+    }
+  };
+
+  return (
+    <Paper
+      withBorder
+      radius="lg"
+      p="md"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        borderColor: selected ? 'var(--mantine-color-blue-5)' : undefined,
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap" align="flex-start">
+        <Group gap={8} wrap="nowrap" style={{ minWidth: 0 }}>
+          <Box
+            w={10}
+            h={10}
+            style={{ borderRadius: '50%', background: meta.dot, flexShrink: 0 }}
+          />
+          <Anchor
+            component={Link}
+            to={`/editor/${snippet.id}`}
+            c="dark.9"
+            fw={600}
+            ff="monospace"
+            fz="md"
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {snippet.name}
+          </Anchor>
+        </Group>
+        <Group gap={10} wrap="nowrap">
+          <Text c="dimmed" fz="sm">
+            {meta.label}
+          </Text>
+          <Checkbox
+            checked={selected}
+            onChange={onToggleSelect}
+            aria-label={`Выбрать сниппет ${snippet.name}`}
+          />
+        </Group>
+      </Group>
+
+      <Group justify="space-between" mt="auto" wrap="nowrap">
+        <Text c="dimmed" fz="sm">
+          {relativeDate(snippet.updatedAt ?? snippet.createdAt)}
+        </Text>
+        <Menu position="bottom-end" width={200} radius="md">
+          <Menu.Target>
+            <ActionIcon variant="subtle" color="gray" aria-label="Действия со сниппетом">
+              <DotsIcon />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item component={Link} to={`/editor/${snippet.id}`}>
+              Открыть
+            </Menu.Item>
+            <Menu.Item onClick={copyLink}>Копировать ссылку</Menu.Item>
+            <Menu.Divider />
+            <Menu.Item color="red" onClick={handleDelete}>
+              Удалить
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Group>
+    </Paper>
+  );
+}

--- a/frontend/src/v2/pages/Dashboard/index.tsx
+++ b/frontend/src/v2/pages/Dashboard/index.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Badge,
+  Box,
+  Button,
+  Center,
+  Chip,
+  Container,
+  Group,
+  Loader,
+  Select,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import AppHeader from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+import { langMeta } from '../../theme';
+import { useSession } from '../../session';
+import { useTRPCClient } from '../../../utils/trpc';
+import SnippetCard from './SnippetCard';
+import NewSnippetModal from './NewSnippetModal';
+import EmptyState from './EmptyState';
+import BulkBar from './BulkBar';
+import { sampleCode, SNIPPETS_QUERY_KEY, type Snippet } from './lib';
+
+function SearchIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="11" cy="11" r="7" />
+      <line x1="16.5" y1="16.5" x2="21" y2="21" />
+    </svg>
+  );
+}
+
+type SortMode = 'new' | 'old' | 'name';
+
+export default function Dashboard() {
+  const { user, isGuest } = useSession();
+  const navigate = useNavigate();
+  const trpc = useTRPCClient();
+  const queryClient = useQueryClient();
+
+  const [search, setSearch] = useState('');
+  const [langFilter, setLangFilter] = useState<string>('all');
+  const [sort, setSort] = useState<SortMode>('new');
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [modalOpened, setModalOpened] = useState(false);
+
+  // Гостям кабинет недоступен — уводим на лендинг.
+  useEffect(() => {
+    if (isGuest) navigate('/', { replace: true });
+  }, [isGuest, navigate]);
+
+  const { data: allSnippets, isLoading } = useQuery({
+    queryKey: SNIPPETS_QUERY_KEY,
+    queryFn: () => trpc.snippets.getAllSnippets.query() as Promise<Snippet[]>,
+    enabled: !isGuest,
+  });
+
+  // TODO(#828): серверная выборка «мои сниппеты» вместо фильтрации всего списка на клиенте.
+  const mySnippets = useMemo(
+    () => (allSnippets ?? []).filter((s) => s.userId === user?.id),
+    [allSnippets, user?.id],
+  );
+
+  const visibleSnippets = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const filtered = mySnippets.filter((s) => {
+      if (langFilter !== 'all' && s.language !== langFilter) return false;
+      if (query && !s.name.toLowerCase().includes(query)) return false;
+      return true;
+    });
+    const sorted = [...filtered];
+    if (sort === 'name') {
+      sorted.sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+    } else {
+      sorted.sort((a, b) => {
+        const da = new Date(a.createdAt).getTime();
+        const db = new Date(b.createdAt).getTime();
+        return sort === 'new' ? db - da : da - db;
+      });
+    }
+    return sorted;
+  }, [mySnippets, search, langFilter, sort]);
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => trpc.snippets.deleteSnippet.mutate({ id }),
+    onSuccess: (_data, id) => {
+      setSelectedIds((prev) => prev.filter((x) => x !== id));
+      queryClient.invalidateQueries({ queryKey: SNIPPETS_QUERY_KEY });
+      notifications.show({ message: 'Сниппет удалён', color: 'blue' });
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось удалить сниппет', color: 'red' });
+    },
+  });
+
+  const createExampleMutation = useMutation({
+    mutationFn: (language: string) =>
+      trpc.snippets.createSnippet.mutate({
+        name: `example-${language}`,
+        code: sampleCode[language] ?? '',
+        language,
+        userId: user!.id,
+      }),
+    onSuccess: (created: { id: number }) => {
+      queryClient.invalidateQueries({ queryKey: SNIPPETS_QUERY_KEY });
+      navigate(`/editor/${created.id}`);
+    },
+    onError: () => {
+      notifications.show({ message: 'Не удалось создать сниппет', color: 'red' });
+    },
+  });
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  };
+
+  if (isGuest) return null;
+
+  const hasAny = mySnippets.length > 0;
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+
+      <Box component="main" py={40} style={{ flex: 1, background: '#f8f9fa' }}>
+        <Container size="lg">
+          <Group justify="space-between" mb="lg" wrap="wrap">
+            <Group gap="sm">
+              <Title order={1} fz={32}>
+                Мои сниппеты
+              </Title>
+              {hasAny && (
+                <Badge size="lg" variant="light" radius="md">
+                  {mySnippets.length}
+                </Badge>
+              )}
+            </Group>
+            <Button onClick={() => setModalOpened(true)}>+ Новый сниппет</Button>
+          </Group>
+
+          {isLoading && (
+            <Center py={80}>
+              <Loader />
+            </Center>
+          )}
+
+          {!isLoading && !hasAny && (
+            <EmptyState
+              onCreateClick={() => setModalOpened(true)}
+              onCreateExample={(lang) => createExampleMutation.mutate(lang)}
+              creating={createExampleMutation.isPending}
+            />
+          )}
+
+          {!isLoading && hasAny && (
+            <>
+              <Group gap="sm" mb="xl" wrap="wrap">
+                <TextInput
+                  value={search}
+                  onChange={(e) => setSearch(e.currentTarget.value)}
+                  placeholder="Поиск по названию…"
+                  leftSection={<SearchIcon />}
+                  radius="xl"
+                  w={{ base: '100%', sm: 280 }}
+                />
+                <Chip
+                  checked={langFilter === 'all'}
+                  onChange={() => setLangFilter('all')}
+                  variant="light"
+                  radius="xl"
+                >
+                  Все
+                </Chip>
+                {Object.entries(langMeta).map(([key, meta]) => (
+                  <Chip
+                    key={key}
+                    checked={langFilter === key}
+                    onChange={() => setLangFilter(langFilter === key ? 'all' : key)}
+                    variant="light"
+                    radius="xl"
+                  >
+                    {meta.label}
+                  </Chip>
+                ))}
+                <Select
+                  value={sort}
+                  onChange={(v) => setSort((v as SortMode) ?? 'new')}
+                  data={[
+                    { value: 'new', label: 'Сначала новые' },
+                    { value: 'old', label: 'Сначала старые' },
+                    { value: 'name', label: 'По имени' },
+                  ]}
+                  allowDeselect={false}
+                  radius="xl"
+                  w={180}
+                  ml="auto"
+                  aria-label="Сортировка"
+                />
+              </Group>
+
+              {visibleSnippets.length === 0 ? (
+                <Center py={64}>
+                  <Text c="dimmed">Ничего не найдено — попробуйте изменить фильтры.</Text>
+                </Center>
+              ) : (
+                <Box
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                    gap: 16,
+                  }}
+                >
+                  {visibleSnippets.map((snippet) => (
+                    <SnippetCard
+                      key={snippet.id}
+                      snippet={snippet}
+                      username={user!.username}
+                      selected={selectedIds.includes(snippet.id)}
+                      onToggleSelect={() => toggleSelect(snippet.id)}
+                      onDelete={() => deleteMutation.mutate(snippet.id)}
+                    />
+                  ))}
+                </Box>
+              )}
+            </>
+          )}
+        </Container>
+      </Box>
+
+      <BulkBar count={selectedIds.length} onClear={() => setSelectedIds([])} />
+      <NewSnippetModal opened={modalOpened} onClose={() => setModalOpened(false)} />
+
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Dashboard/lib.ts
+++ b/frontend/src/v2/pages/Dashboard/lib.ts
@@ -1,0 +1,108 @@
+// Общие типы и утилиты личного кабинета «Мои сниппеты».
+
+export type Snippet = {
+  id: number;
+  name: string;
+  slug: string;
+  code: string;
+  language: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const SNIPPETS_QUERY_KEY = ['v2', 'snippets', 'all'] as const;
+
+const plural = (n: number, forms: [string, string, string]): string => {
+  const m10 = n % 10;
+  const m100 = n % 100;
+  if (m10 === 1 && m100 !== 11) return forms[0];
+  if (m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14)) return forms[1];
+  return forms[2];
+};
+
+// Относительная дата по-русски: «2 часа назад», «вчера», «месяц назад».
+export function relativeDate(input: string | Date): string {
+  if (!input) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
+  const date = new Date(input);
+  const diffMs = Date.now() - date.getTime();
+  if (Number.isNaN(date.getTime())) return '';
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'только что';
+  if (minutes < 60) {
+    return `${minutes} ${plural(minutes, ['минуту', 'минуты', 'минут'])} назад`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} ${plural(hours, ['час', 'часа', 'часов'])} назад`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'вчера';
+  if (days < 7) return `${days} ${plural(days, ['день', 'дня', 'дней'])} назад`;
+  if (days < 30) {
+    const weeks = Math.floor(days / 7);
+    return weeks === 1
+      ? 'неделю назад'
+      : `${weeks} ${plural(weeks, ['неделю', 'недели', 'недель'])} назад`;
+  }
+  const months = Math.floor(days / 30);
+  if (months < 12) {
+    return months === 1
+      ? 'месяц назад'
+      : `${months} ${plural(months, ['месяц', 'месяца', 'месяцев'])} назад`;
+  }
+  const years = Math.floor(months / 12);
+  return years === 1 ? 'год назад' : `${years} ${plural(years, ['год', 'года', 'лет'])} назад`;
+}
+
+// Стартовые примеры кода для «Начать с примера кода» и карточек пустого состояния.
+export const sampleCode: Record<string, string> = {
+  javascript: [
+    '// Пример: сумма корзины со скидкой',
+    'const cart = [120, 250, 80];',
+    'const total = cart.reduce((acc, price) => acc + price, 0);',
+    "console.log('Итого со скидкой 10%:', total * 0.9);",
+  ].join('\n'),
+  typescript: [
+    '// Пример: сужение типов',
+    'type Shape = { kind: "circle"; r: number } | { kind: "square"; size: number };',
+    'const area = (s: Shape) =>',
+    '  s.kind === "circle" ? Math.PI * s.r ** 2 : s.size ** 2;',
+    'console.log(area({ kind: "circle", r: 2 }));',
+  ].join('\n'),
+  python: [
+    '# Пример: числа Фибоначчи',
+    'def fib(n):',
+    '    a, b = 0, 1',
+    '    for _ in range(n):',
+    '        a, b = b, a + b',
+    '    return a',
+    '',
+    'print([fib(i) for i in range(10)])',
+  ].join('\n'),
+  php: [
+    '<?php',
+    '// Пример: валидация email',
+    "$email = 'user@example.com';",
+    'var_dump(filter_var($email, FILTER_VALIDATE_EMAIL));',
+  ].join('\n'),
+  ruby: [
+    '# Пример: обёртка с повторными запросами',
+    '3.times do |attempt|',
+    '  puts "Попытка #{attempt + 1}"',
+    'end',
+  ].join('\n'),
+  java: [
+    'public class Main {',
+    '    public static void main(String[] args) {',
+    '        System.out.println("Привет, Runit!");',
+    '    }',
+    '}',
+  ].join('\n'),
+  html: [
+    '<!doctype html>',
+    '<html lang="ru">',
+    '  <body>',
+    '    <h1>Привет, Runit!</h1>',
+    '  </body>',
+    '</html>',
+  ].join('\n'),
+};

--- a/frontend/src/v2/pages/Editor/AddPackageModal.tsx
+++ b/frontend/src/v2/pages/Editor/AddPackageModal.tsx
@@ -1,0 +1,82 @@
+import {
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+
+// TODO(#823, #824): настоящий менеджер пакетов (поиск по npm, установка,
+// runit.lock). Пока модалка-заглушка со статичным списком популярных пакетов.
+
+const POPULAR_PACKAGES = [
+  { name: 'lodash', version: '4.17.21', description: 'Утилиты для работы с данными' },
+  { name: 'axios', version: '1.7.2', description: 'HTTP-клиент' },
+  { name: 'dayjs', version: '1.11.11', description: 'Даты и время, 2 КБ' },
+  { name: 'zod', version: '3.23.8', description: 'Валидация схем' },
+  { name: 'nanoid', version: '5.0.7', description: 'Генератор коротких ID' },
+];
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+};
+
+export default function AddPackageModal({ opened, onClose }: Props) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      centered
+      radius="lg"
+      size="md"
+      title={
+        <Group gap="xs">
+          <Text fw={800} fz="lg">
+            Добавить пакет
+          </Text>
+          <Badge variant="light" color="gray" radius="sm" tt="lowercase">
+            npm
+          </Badge>
+        </Group>
+      }
+    >
+      <Stack gap="md">
+        <TextInput placeholder="Название пакета…" />
+
+        <Stack gap="sm">
+          {POPULAR_PACKAGES.map((pkg) => (
+            <Group key={pkg.name} justify="space-between" wrap="nowrap">
+              <div>
+                <Group gap={8}>
+                  <Text ff="monospace" fw={700} fz="sm">
+                    {pkg.name}
+                  </Text>
+                  <Text fz="xs" c="dimmed">
+                    {pkg.version}
+                  </Text>
+                </Group>
+                <Text fz="sm" c="dimmed">
+                  {pkg.description}
+                </Text>
+              </div>
+              <Tooltip label="В разработке (#823/#824)" withArrow>
+                <Button variant="outline" size="xs" data-disabled onClick={(e) => e.preventDefault()}>
+                  Установить
+                </Button>
+              </Tooltip>
+            </Group>
+          ))}
+        </Stack>
+
+        <Text fz="sm" c="dimmed">
+          Менеджер пакетов появится позже (#823/#824). Версии будут фиксироваться
+          в runit.lock и подтягиваться при каждом запуске.
+        </Text>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/v2/pages/Editor/ConsolePanel.tsx
+++ b/frontend/src/v2/pages/Editor/ConsolePanel.tsx
@@ -1,0 +1,175 @@
+import { Box, Group, Loader, Text, Tooltip, UnstyledButton } from '@mantine/core';
+import { editorColors } from '../../theme';
+import type { ConsoleLine } from '../../runner';
+import { IconTrash } from './icons';
+
+export type OutputTab = 'console' | 'input';
+
+const lineColor: Record<ConsoleLine['type'], string> = {
+  log: editorColors.text,
+  error: editorColors.error,
+  warn: '#e5c07b',
+  info: editorColors.accent,
+  system: editorColors.dim,
+};
+
+type Props = {
+  tab: OutputTab;
+  onTabChange: (tab: OutputTab) => void;
+  lines: ConsoleLine[];
+  running: boolean;
+  stdin: string;
+  onStdinChange: (value: string) => void;
+  onClear: () => void;
+};
+
+function TabButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <UnstyledButton
+      onClick={onClick}
+      px={4}
+      style={{
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        fontSize: 12,
+        fontWeight: 700,
+        letterSpacing: '0.08em',
+        color: active ? editorColors.text : editorColors.dim,
+        borderBottom: `2px solid ${active ? editorColors.accent : 'transparent'}`,
+      }}
+    >
+      {label}
+    </UnstyledButton>
+  );
+}
+
+export default function ConsolePanel({
+  tab,
+  onTabChange,
+  lines,
+  running,
+  stdin,
+  onStdinChange,
+  onClear,
+}: Props) {
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: editorColors.panel,
+        borderLeft: `1px solid ${editorColors.border}`,
+        minWidth: 0,
+      }}
+    >
+      <Group
+        justify="space-between"
+        px="md"
+        gap="lg"
+        style={{
+          height: 40,
+          flexShrink: 0,
+          borderBottom: `1px solid ${editorColors.border}`,
+        }}
+      >
+        <Group gap="lg" style={{ height: '100%' }}>
+          <TabButton
+            active={tab === 'console'}
+            label="КОНСОЛЬ"
+            onClick={() => onTabChange('console')}
+          />
+          <TabButton
+            active={tab === 'input'}
+            label="ВВОД"
+            onClick={() => onTabChange('input')}
+          />
+        </Group>
+        <Tooltip label="Очистить консоль" withArrow>
+          <UnstyledButton
+            onClick={onClear}
+            aria-label="Очистить консоль"
+            style={{ color: editorColors.dim, display: 'flex' }}
+          >
+            <IconTrash />
+          </UnstyledButton>
+        </Tooltip>
+      </Group>
+
+      {tab === 'console' ? (
+        <Box
+          p="md"
+          ff="monospace"
+          fz={13}
+          style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
+        >
+          <Text ff="monospace" fz={13} c={editorColors.dim} mb={8}>
+            Runit · Node.js 20 LTS{' '}
+            {lines.length === 0 && !running ? '· консоль готова' : ''}
+          </Text>
+          {running ? (
+            <Group gap={8}>
+              <Loader size={12} color={editorColors.accent} />
+              <Text ff="monospace" fz={13} c={editorColors.dim}>
+                Выполняется…
+              </Text>
+            </Group>
+          ) : lines.length === 0 ? (
+            <Text ff="monospace" fz={13} c={editorColors.dim}>
+              Консоль пуста. Нажмите «Выполнить» или Ctrl + Enter.
+            </Text>
+          ) : (
+            lines.map((line, i) => (
+              <Text
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                ff="monospace"
+                fz={13}
+                style={{
+                  color: lineColor[line.type],
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {line.text}
+              </Text>
+            ))
+          )}
+        </Box>
+      ) : (
+        <Box p="md" style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <Text fz={12} c={editorColors.dim} mb={8}>
+            Передаётся в stdin при каждом запуске
+          </Text>
+          <textarea
+            value={stdin}
+            onChange={(e) => onStdinChange(e.currentTarget.value)}
+            placeholder="Каждая строка — отдельный вызов readline()"
+            spellCheck={false}
+            style={{
+              flex: 1,
+              resize: 'none',
+              background: editorColors.bg,
+              color: editorColors.text,
+              border: `1px solid ${editorColors.border}`,
+              borderRadius: 8,
+              padding: 12,
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+              fontSize: 13,
+              outline: 'none',
+            }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/v2/pages/Editor/ShareModal.tsx
+++ b/frontend/src/v2/pages/Editor/ShareModal.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Anchor,
+  Button,
+  Code,
+  Divider,
+  Group,
+  Modal,
+  SegmentedControl,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+  username: string;
+  slug: string;
+  saved: boolean;
+};
+
+function copyToClipboard(value: string, message: string) {
+  navigator.clipboard
+    .writeText(value)
+    .then(() => notifications.show({ message, color: 'teal' }))
+    .catch(() =>
+      notifications.show({ message: 'Не удалось скопировать', color: 'red' }),
+    );
+}
+
+export default function ShareModal({ opened, onClose, username, slug, saved }: Props) {
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
+  const [height, setHeight] = useState('380');
+
+  const origin = window.location.origin;
+  const pagePath = `/s/${username}/${slug}`;
+  const shareUrl = `${origin}${pagePath}`;
+  const embedCode = `<iframe src="${origin}/embed/${username}/${slug}?theme=${theme}&height=${height}" width="100%" height="${height}" style="border:0;border-radius:12px" title="Runit"></iframe>`;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={<Text fw={800} fz="lg">Поделиться сниппетом</Text>}
+      centered
+      radius="lg"
+      size="lg"
+    >
+      <Stack gap="md">
+        <Group justify="space-between" wrap="nowrap">
+          <div>
+            <Text fw={600}>Доступ по ссылке</Text>
+            <Text fz="sm" c="dimmed">
+              Просматривать могут все, у кого есть ссылка
+            </Text>
+          </div>
+          {/* TODO(#643, #828): реальное управление приватностью — тумблер пока визуальный */}
+          <Switch defaultChecked size="md" />
+        </Group>
+
+        <div>
+          <Text fz={11} fw={700} c="dimmed" mb={6} style={{ letterSpacing: '0.08em' }}>
+            ССЫЛКА
+          </Text>
+          <Group gap="sm" wrap="nowrap">
+            <TextInput value={shareUrl} readOnly style={{ flex: 1 }} ff="monospace" />
+            <Button
+              variant="light"
+              onClick={() => copyToClipboard(shareUrl, 'Ссылка скопирована')}
+            >
+              Копировать
+            </Button>
+          </Group>
+          {!saved && (
+            <Text fz="xs" c="dimmed" mt={4}>
+              Ссылка станет активной после сохранения сниппета
+            </Text>
+          )}
+        </div>
+
+        <Divider />
+
+        <div>
+          <Text fz={11} fw={700} c="dimmed" mb={6} style={{ letterSpacing: '0.08em' }}>
+            ВСТРОИТЬ НА САЙТ
+          </Text>
+          <Group gap="sm" mb="sm">
+            <SegmentedControl
+              value={theme}
+              onChange={(v) => setTheme(v as 'dark' | 'light')}
+              data={[
+                { value: 'dark', label: 'Тёмная' },
+                { value: 'light', label: 'Светлая' },
+              ]}
+            />
+            <Select
+              value={height}
+              onChange={(v) => setHeight(v ?? '380')}
+              data={[
+                { value: '280', label: 'Высота 280' },
+                { value: '380', label: 'Высота 380' },
+                { value: '520', label: 'Высота 520' },
+              ]}
+              w={150}
+              allowDeselect={false}
+            />
+          </Group>
+          {/* TODO(#841): опции «Показывать результат / Только чтение / Автозапуск» для embed */}
+          <Code block style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {embedCode}
+          </Code>
+          <Group justify="space-between" mt="sm">
+            <Text fz="sm" c="dimmed">
+              Код обновляется при смене настроек
+            </Text>
+            <Button
+              variant="default"
+              onClick={() => copyToClipboard(embedCode, 'Код для вставки скопирован')}
+            >
+              Копировать код
+            </Button>
+          </Group>
+        </div>
+
+        <Divider />
+
+        <Group justify="space-between">
+          <Anchor component={Link} to={pagePath} fw={600}>
+            Страница сниппета →
+          </Anchor>
+          <Button onClick={onClose}>Готово</Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/v2/pages/Editor/icons.tsx
+++ b/frontend/src/v2/pages/Editor/icons.tsx
@@ -1,0 +1,81 @@
+// Инлайн-иконки (без сторонних icon-паков — в проекте только Mantine).
+type IconProps = { size?: number; color?: string };
+
+const base = (size: number) => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  fill: 'none' as const,
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+});
+
+export function IconArrowLeft({ size = 18 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <path d="M19 12H5" />
+      <path d="m12 19-7-7 7-7" />
+    </svg>
+  );
+}
+
+export function IconHistory({ size = 18 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+      <path d="M3 3v5h5" />
+      <path d="M12 7v5l3 3" />
+    </svg>
+  );
+}
+
+export function IconUsers({ size = 18 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <circle cx="9" cy="7" r="4" />
+      <path d="M2 21v-2a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4v2" />
+      <path d="M16 3.1a4 4 0 0 1 0 7.8" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.9" />
+    </svg>
+  );
+}
+
+export function IconShare({ size = 16 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4" />
+    </svg>
+  );
+}
+
+export function IconPlay({ size = 14 }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  );
+}
+
+export function IconTrash({ size = 16 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <path d="M3 6h18" />
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+      <path d="M10 11v6M14 11v6" />
+    </svg>
+  );
+}
+
+export function IconPlus({ size = 16 }: IconProps) {
+  return (
+    <svg {...base(size)}>
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}

--- a/frontend/src/v2/pages/Editor/index.tsx
+++ b/frontend/src/v2/pages/Editor/index.tsx
@@ -1,0 +1,637 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  ActionIcon,
+  Avatar,
+  Box,
+  Button,
+  Center,
+  Group,
+  Loader,
+  Menu,
+  Stack,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from '@mantine/core';
+import { useQuery } from '@tanstack/react-query';
+import MonacoEditor, { type OnMount } from '@monaco-editor/react';
+import { notifications } from '@mantine/notifications';
+
+import { useTRPCClient } from '../../../utils/trpc';
+import { editorColors, langMeta } from '../../theme';
+import { useSession } from '../../session';
+import { useAuthModal } from '../../components/AuthModal/context';
+import { RunitLogo, initialsOf } from '../../components/AppHeader';
+import { runJavaScript, unsupportedLanguage, type ConsoleLine } from '../../runner';
+import ConsolePanel, { type OutputTab } from './ConsolePanel';
+import ShareModal from './ShareModal';
+import AddPackageModal from './AddPackageModal';
+import {
+  IconArrowLeft,
+  IconHistory,
+  IconPlay,
+  IconPlus,
+  IconShare,
+  IconUsers,
+} from './icons';
+
+// Экран редактора Runit v2 (docs/design/editor.png).
+// TODO(#821, #609): серверное исполнение — сейчас JS выполняется в Web Worker,
+// остальные языки отвечают заглушкой unsupportedLanguage.
+
+type SaveStatus = 'saved' | 'saving' | 'unsaved';
+
+const FILE_NAME_BY_LANGUAGE: Record<string, string> = {
+  javascript: 'index.js',
+  typescript: 'index.ts',
+  python: 'main.py',
+  php: 'index.php',
+  ruby: 'main.rb',
+  java: 'Main.java',
+  html: 'index.html',
+};
+
+const STARTER_CODE = `// Корзина курса: считаем итоговую стоимость
+const items = [
+  { title: 'JS: Массивы', price: 3900 },
+  { title: 'JS: Функции', price: 4900 },
+  { title: 'JS: Объекты', price: 4400 },
+];
+
+const sum = (nums) => nums.reduce((acc, n) => acc + n, 0);
+const total = sum(items.map((item) => item.price));
+
+console.log('Позиций в корзине:', items.length);
+console.log('Сумма без скидки:', total, '₽');
+`;
+
+const SAVE_STATUS_META: Record<SaveStatus, { color: string; label: string }> = {
+  saved: { color: '#51cf66', label: 'Сохранено' },
+  saving: { color: '#4dabf7', label: 'Сохранение…' },
+  unsaved: { color: '#adb5bd', label: 'Не сохранено' },
+};
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Text fz={11} fw={700} c="dimmed" style={{ letterSpacing: '0.08em' }}>
+      {children}
+    </Text>
+  );
+}
+
+export default function EditorPage() {
+  const { id } = useParams();
+  const snippetId = id ? Number(id) : null;
+  const navigate = useNavigate();
+  const trpc = useTRPCClient();
+  const { user, isGuest } = useSession();
+  const auth = useAuthModal();
+
+  const [name, setName] = useState('');
+  const [code, setCode] = useState(STARTER_CODE);
+  const [language, setLanguage] = useState('javascript');
+  const [slug, setSlug] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('unsaved');
+  const [stdin, setStdin] = useState('');
+  const [lines, setLines] = useState<ConsoleLine[]>([]);
+  const [running, setRunning] = useState(false);
+  const [tab, setTab] = useState<OutputTab>('console');
+  const [cursor, setCursor] = useState({ line: 1, col: 1 });
+  const [shareOpened, setShareOpened] = useState(false);
+  const [packageOpened, setPackageOpened] = useState(false);
+
+  // Рефы для стабильных колбэков (хоткей, monaco-команда, debounce).
+  const nameRef = useRef(name);
+  const codeRef = useRef(code);
+  const stdinRef = useRef(stdin);
+  const languageRef = useRef(language);
+  nameRef.current = name;
+  codeRef.current = code;
+  stdinRef.current = stdin;
+  languageRef.current = language;
+
+  const initializedFor = useRef<string>('');
+
+  // --- Данные -------------------------------------------------------------
+  const snippetQuery = useQuery({
+    queryKey: ['v2-editor-snippet', snippetId],
+    queryFn: () => trpc.snippets.getSnippetById.query(snippetId as number),
+    enabled: snippetId != null,
+    retry: false,
+  });
+
+  const ownerQuery = useQuery({
+    queryKey: ['v2-editor-owner', snippetQuery.data?.userId],
+    queryFn: () => trpc.users.getUserById.query(snippetQuery.data!.userId),
+    enabled: snippetQuery.data?.userId != null,
+  });
+
+  const draftNameQuery = useQuery({
+    queryKey: ['v2-editor-draft-name'],
+    queryFn: () => trpc.snippets.generateSnippetName.query(),
+    enabled: snippetId == null,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    if (snippetId != null && snippetQuery.data && initializedFor.current !== `id:${snippetId}`) {
+      initializedFor.current = `id:${snippetId}`;
+      setName(snippetQuery.data.name);
+      setCode(snippetQuery.data.code);
+      setLanguage(snippetQuery.data.language);
+      setSlug(snippetQuery.data.slug);
+      setSaveStatus('saved');
+    }
+  }, [snippetId, snippetQuery.data]);
+
+  useEffect(() => {
+    if (snippetId == null && draftNameQuery.data && initializedFor.current === '') {
+      initializedFor.current = 'draft';
+      setName(draftNameQuery.data.name);
+    }
+  }, [snippetId, draftNameQuery.data]);
+
+  // --- Сохранение ---------------------------------------------------------
+  // TODO(#826): разрешение конфликтов и оффлайн-черновики.
+  const savingRef = useRef(false);
+  const snippetIdRef = useRef(snippetId);
+  snippetIdRef.current = snippetId;
+
+  const saveNow = useCallback(async () => {
+    if (isGuest || !user) {
+      auth.open('register');
+      return;
+    }
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setSaveStatus('saving');
+    try {
+      if (snippetIdRef.current == null) {
+        const created = await trpc.snippets.createSnippet.mutate({
+          name: nameRef.current,
+          code: codeRef.current,
+          language: languageRef.current,
+          userId: user.id,
+        });
+        initializedFor.current = `id:${created.id}`;
+        setSlug(created.slug);
+        setSaveStatus('saved');
+        navigate(`/editor/${created.id}`, { replace: true });
+      } else {
+        await trpc.snippets.updateSnippet.mutate({
+          id: snippetIdRef.current,
+          name: nameRef.current,
+          code: codeRef.current,
+          language: languageRef.current,
+        });
+        setSaveStatus('saved');
+      }
+    } catch {
+      setSaveStatus('unsaved');
+      notifications.show({ message: 'Не удалось сохранить сниппет', color: 'red' });
+    } finally {
+      savingRef.current = false;
+    }
+  }, [isGuest, user, auth, trpc, navigate]);
+
+  // Автосохранение с debounce 1.5 c — только для сохранённого сниппета юзера.
+  useEffect(() => {
+    if (saveStatus !== 'unsaved') return undefined;
+    if (isGuest || snippetId == null) return undefined;
+    const timer = setTimeout(() => {
+      void saveNow();
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [saveStatus, name, code, isGuest, snippetId, saveNow]);
+
+  const markDirty = useCallback(() => setSaveStatus('unsaved'), []);
+
+  // --- Запуск -------------------------------------------------------------
+  const runningRef = useRef(false);
+  const handleRun = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setRunning(true);
+    setTab('console');
+    const result =
+      languageRef.current === 'javascript'
+        ? await runJavaScript(codeRef.current, stdinRef.current)
+        : unsupportedLanguage(languageRef.current);
+    setLines([
+      ...result.lines,
+      {
+        type: 'system',
+        text: `Процесс завершён с кодом ${result.exitCode} за ${Math.max(1, Math.round(result.durationMs))} мс`,
+      },
+    ]);
+    runningRef.current = false;
+    setRunning(false);
+  }, []);
+
+  const runRef = useRef(handleRun);
+  runRef.current = handleRun;
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        void runRef.current();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const handleEditorMount: OnMount = (editor, monaco) => {
+    editor.onDidChangeCursorPosition((e) => {
+      setCursor({ line: e.position.lineNumber, col: e.position.column });
+    });
+    // eslint-disable-next-line no-bitwise
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+      void runRef.current();
+    });
+  };
+
+  // --- Ранние состояния ---------------------------------------------------
+  if (snippetId != null && snippetQuery.isLoading) {
+    return (
+      <Center h="100vh">
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (snippetId != null && snippetQuery.isError) {
+    return (
+      <Center h="100vh">
+        <Stack align="center" gap="sm">
+          <Text fw={700} fz="lg">Сниппет не найден</Text>
+          <Button component={Link} to="/snippets" variant="light">
+            К моим сниппетам
+          </Button>
+        </Stack>
+      </Center>
+    );
+  }
+
+  const meta = langMeta[language] ?? { label: language, dot: '#adb5bd', runnable: false };
+  const fileName = FILE_NAME_BY_LANGUAGE[language] ?? 'index.txt';
+  const statusMeta = SAVE_STATUS_META[saveStatus];
+  const shareUsername = ownerQuery.data?.username ?? user?.username ?? 'guest';
+
+  return (
+    <div
+      style={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        background: '#f8f9fa',
+      }}
+    >
+      {/* ===== Верхняя панель (52px) ===== */}
+      <Group
+        component="header"
+        px="md"
+        justify="space-between"
+        wrap="nowrap"
+        style={{
+          height: 52,
+          flexShrink: 0,
+          background: '#fff',
+          borderBottom: '1px solid #e9ecef',
+        }}
+      >
+        <Group gap="sm" wrap="nowrap" style={{ minWidth: 0 }}>
+          <Tooltip label="К моим сниппетам" withArrow>
+            <ActionIcon
+              component={Link}
+              to="/snippets"
+              variant="subtle"
+              color="gray"
+              aria-label="Назад к сниппетам"
+            >
+              <IconArrowLeft />
+            </ActionIcon>
+          </Tooltip>
+          <UnstyledButton component={Link} to="/">
+            <RunitLogo size={26} />
+          </UnstyledButton>
+          <input
+            value={name}
+            onChange={(e) => {
+              setName(e.currentTarget.value);
+              markDirty();
+            }}
+            placeholder="имя-сниппета"
+            aria-label="Имя сниппета"
+            spellCheck={false}
+            style={{
+              border: 'none',
+              outline: 'none',
+              background: 'transparent',
+              fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+              fontSize: 15,
+              fontWeight: 600,
+              color: '#212529',
+              width: 200,
+              minWidth: 0,
+            }}
+          />
+          <Group
+            gap={6}
+            px={10}
+            py={4}
+            wrap="nowrap"
+            style={{ background: '#f1f3f5', borderRadius: 8, flexShrink: 0 }}
+          >
+            <Box w={8} h={8} style={{ borderRadius: '50%', background: meta.dot }} />
+            <Text fz="sm" fw={600} c="dark.5">
+              {meta.label}
+            </Text>
+          </Group>
+          <Tooltip
+            label={
+              isGuest
+                ? 'Зарегистрируйтесь, чтобы сохранять сниппеты'
+                : 'Сохранить сейчас (автосохранение — 1,5 с)'
+            }
+            withArrow
+          >
+            <UnstyledButton onClick={() => void saveNow()}>
+              <Group gap={6} wrap="nowrap">
+                <Box
+                  w={8}
+                  h={8}
+                  style={{ borderRadius: '50%', background: statusMeta.color }}
+                />
+                <Text fz="sm" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                  {statusMeta.label}
+                </Text>
+              </Group>
+            </UnstyledButton>
+          </Tooltip>
+        </Group>
+
+        <Group gap="sm" wrap="nowrap">
+          {/* TODO(#836, #837): история версий со снапшотами и diff */}
+          <Tooltip label="В разработке (#836/#837)" withArrow>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              data-disabled
+              onClick={(e) => e.preventDefault()}
+              aria-label="История версий"
+            >
+              <IconHistory />
+            </ActionIcon>
+          </Tooltip>
+          {/* TODO(#3, #838): совместное редактирование в реальном времени */}
+          <Tooltip label="В разработке (#3/#838)" withArrow>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              data-disabled
+              onClick={(e) => e.preventDefault()}
+              aria-label="Совместная сессия"
+            >
+              <IconUsers />
+            </ActionIcon>
+          </Tooltip>
+          <Button
+            variant="light"
+            leftSection={<IconShare />}
+            onClick={() => setShareOpened(true)}
+          >
+            Поделиться
+          </Button>
+          <Tooltip label="Ctrl + Enter" withArrow>
+            <Button
+              leftSection={<IconPlay />}
+              onClick={() => void handleRun()}
+              disabled={running}
+            >
+              {running ? 'Выполняется…' : 'Выполнить'}
+            </Button>
+          </Tooltip>
+          {isGuest ? (
+            <Button variant="subtle" color="gray" onClick={() => auth.open('login')}>
+              Войти
+            </Button>
+          ) : (
+            <Menu position="bottom-end" width={180} radius="md">
+              <Menu.Target>
+                <UnstyledButton>
+                  <Avatar color="blue" radius="xl" size={34}>
+                    {initialsOf(user!.username)}
+                  </Avatar>
+                </UnstyledButton>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Label>{user!.username}</Menu.Label>
+                <Menu.Item component={Link} to="/snippets">
+                  Мои сниппеты
+                </Menu.Item>
+                <Menu.Item component={Link} to={`/u/${user!.username}`}>
+                  Профиль
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          )}
+        </Group>
+      </Group>
+
+      {/* ===== Основная область ===== */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+        {/* --- Левый сайдбар (212px) --- */}
+        <Box
+          component="aside"
+          w={212}
+          style={{
+            flexShrink: 0,
+            background: '#fff',
+            borderRight: '1px solid #e9ecef',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <Group justify="space-between" px="md" pt="md" pb={6}>
+            <SectionLabel>ФАЙЛЫ</SectionLabel>
+            {/* TODO(#818, #819): мультифайловые сниппеты */}
+            <Tooltip label="Мультифайловость — #818/#819" withArrow>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                data-disabled
+                onClick={(e) => e.preventDefault()}
+                aria-label="Добавить файл"
+              >
+                <IconPlus size={14} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+          <Box px={8}>
+            <Group
+              gap={8}
+              px={10}
+              py={8}
+              wrap="nowrap"
+              style={{
+                background: 'var(--mantine-color-blue-0)',
+                borderRadius: 8,
+              }}
+            >
+              <Box w={8} h={8} style={{ borderRadius: '50%', background: meta.dot }} />
+              <Text ff="monospace" fz="sm" fw={600} c="blue.7">
+                {fileName}
+              </Text>
+            </Group>
+          </Box>
+
+          <div style={{ flex: 1 }} />
+
+          <Group justify="space-between" px="md" pb={6}>
+            <SectionLabel>ПАКЕТЫ</SectionLabel>
+            <Tooltip label="Добавить пакет" withArrow>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                onClick={() => setPackageOpened(true)}
+                aria-label="Добавить пакет"
+              >
+                <IconPlus size={14} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+          <Text px="md" pb="sm" fz="sm" c="dimmed">
+            Нет зависимостей
+          </Text>
+          <Text
+            px="md"
+            py={10}
+            fz="xs"
+            c="dimmed"
+            style={{ borderTop: '1px solid #e9ecef' }}
+          >
+            Node.js 20 LTS
+          </Text>
+        </Box>
+
+        {/* --- Центр: редактор кода --- */}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            background: editorColors.bg,
+          }}
+        >
+          <Box
+            style={{
+              height: 40,
+              flexShrink: 0,
+              display: 'flex',
+              background: editorColors.panel,
+              borderBottom: `1px solid ${editorColors.border}`,
+            }}
+          >
+            <Box
+              px="lg"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                background: editorColors.bg,
+                borderTop: `2px solid ${editorColors.accent}`,
+                borderRight: `1px solid ${editorColors.border}`,
+              }}
+            >
+              <Text ff="monospace" fz={13} style={{ color: editorColors.text }}>
+                {fileName}
+              </Text>
+            </Box>
+          </Box>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <MonacoEditor
+              theme="vs-dark"
+              language={language}
+              value={code}
+              onChange={(value) => {
+                setCode(value ?? '');
+                markDirty();
+              }}
+              onMount={handleEditorMount}
+              loading={<Loader color={editorColors.accent} />}
+              options={{
+                fontSize: 14,
+                fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                minimap: { enabled: false },
+                tabSize: 2,
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                padding: { top: 14 },
+                renderLineHighlight: 'line',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* --- Правая панель: консоль/ввод (~40%) --- */}
+        <div style={{ width: '40%', maxWidth: 640, flexShrink: 0, minWidth: 260 }}>
+          <ConsolePanel
+            tab={tab}
+            onTabChange={setTab}
+            lines={lines}
+            running={running}
+            stdin={stdin}
+            onStdinChange={setStdin}
+            onClear={() => setLines([])}
+          />
+        </div>
+      </div>
+
+      {/* ===== Статус-бар (28px) ===== */}
+      <Group
+        px="md"
+        justify="space-between"
+        wrap="nowrap"
+        style={{
+          height: 28,
+          flexShrink: 0,
+          background: '#fff',
+          borderTop: '1px solid #e9ecef',
+        }}
+      >
+        <Group gap="lg" wrap="nowrap">
+          <Text fz={12} c="dimmed">{meta.label}</Text>
+          <Text fz={12} c="dimmed">Node.js 20 LTS</Text>
+          <Text fz={12} c="dimmed">
+            Строка {cursor.line}, столбец {cursor.col}
+          </Text>
+          <Text fz={12} c="dimmed">Отступ: 2 пробела</Text>
+        </Group>
+        <Group gap="lg" wrap="nowrap">
+          <Text fz={12} c="dimmed">UTF-8</Text>
+          <Text fz={12} c="dimmed">Runit v2.1 · MVP</Text>
+        </Group>
+      </Group>
+
+      <ShareModal
+        opened={shareOpened}
+        onClose={() => setShareOpened(false)}
+        username={shareUsername}
+        slug={slug ?? 'draft'}
+        saved={snippetIdRef.current != null || slug != null}
+      />
+      <AddPackageModal opened={packageOpened} onClose={() => setPackageOpened(false)} />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Embed/index.tsx
+++ b/frontend/src/v2/pages/Embed/index.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { Anchor, Box, Button, Center, Group, Loader, Text } from '@mantine/core';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPCClient } from '../../../utils/trpc';
+import { editorColors, langMeta } from '../../theme';
+import { runJavaScript, unsupportedLanguage, type RunResult } from '../../runner';
+
+// Компактный embed-виджет (без AppHeader/AppFooter — страница живёт внутри iframe).
+// TODO(#841): варианты оформления card/minimal/tabs (query-параметр variant).
+
+type Snippet = {
+  id: number;
+  name: string;
+  slug: string;
+  code: string;
+  language: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const EXT: Record<string, string> = {
+  javascript: 'js',
+  python: 'py',
+  php: 'php',
+  ruby: 'rb',
+  java: 'java',
+  html: 'html',
+};
+
+function lineColor(type: string): string {
+  if (type === 'error') return editorColors.error;
+  if (type === 'warn') return '#e5c07b';
+  if (type === 'system') return editorColors.dim;
+  return editorColors.text;
+}
+
+export default function Embed() {
+  const { username = '', slug = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const trpc = useTRPCClient();
+
+  const theme = searchParams.get('theme') === 'dark' ? 'dark' : 'light';
+  const heightParam = Number(searchParams.get('height'));
+  const widgetHeight = Number.isFinite(heightParam) && heightParam > 0 ? heightParam : null;
+
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const { data: snippet, isLoading, isError } = useQuery({
+    queryKey: ['v2', 'embed-snippet', username, slug],
+    queryFn: () => trpc.snippets.getSnippetByUsernameSlug.query({ username, slug }),
+    retry: false,
+  });
+
+  // Палитра «рамки» виджета: тёмная или светлая по query-параметру theme.
+  const frame =
+    theme === 'dark'
+      ? {
+          bg: editorColors.panel,
+          border: editorColors.border,
+          text: editorColors.text,
+          dim: editorColors.dim,
+        }
+      : {
+          bg: '#ffffff',
+          border: '#e9ecef',
+          text: '#212529',
+          dim: '#868e96',
+        };
+
+  const run = async (s: Snippet) => {
+    const meta = langMeta[s.language];
+    if (!meta?.runnable) {
+      setResult(unsupportedLanguage(meta?.label ?? s.language));
+      return;
+    }
+    setRunning(true);
+    try {
+      setResult(await runJavaScript(s.code));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Center h="100vh">
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  if (isError || !snippet) {
+    return (
+      <Center h="100vh">
+        <Text c="dimmed" fz="sm">
+          Сниппет не найден
+        </Text>
+      </Center>
+    );
+  }
+
+  const s = snippet as Snippet;
+  const meta = langMeta[s.language];
+  const fileName = `${s.name}.${EXT[s.language] ?? 'txt'}`;
+  const shareHref = `/s/${username}/${slug}`;
+
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: widgetHeight ? widgetHeight : '100vh',
+        maxHeight: '100vh',
+        border: `1px solid ${frame.border}`,
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: frame.bg,
+      }}
+    >
+      {/* Шапка виджета */}
+      <Group justify="space-between" px="md" py={8} style={{ borderBottom: `1px solid ${frame.border}` }}>
+        <Group gap={8} wrap="nowrap" style={{ minWidth: 0 }}>
+          <Text ff="monospace" fz="sm" c={frame.text} truncate>
+            {fileName}
+          </Text>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              flexShrink: 0,
+              background: meta?.dot ?? '#adb5bd',
+            }}
+          />
+          <Text fz="xs" c={frame.dim} visibleFrom="xs">
+            {meta?.label ?? s.language}
+          </Text>
+        </Group>
+        <Group gap="sm" wrap="nowrap">
+          <Anchor href={shareHref} target="_blank" rel="noopener noreferrer" fz="sm" fw={600}>
+            Открыть в Runit ↗
+          </Anchor>
+          <Button size="compact-sm" onClick={() => run(s)} loading={running} leftSection={<span aria-hidden>▶</span>}>
+            Запустить
+          </Button>
+        </Group>
+      </Group>
+
+      {/* Код (read-only) */}
+      <Box style={{ flex: 1, minHeight: 0, overflow: 'auto', background: editorColors.bg, padding: '12px 16px' }}>
+        <pre style={{ margin: 0, fontFamily: 'var(--mantine-font-family-monospace)', fontSize: 13, lineHeight: 1.65 }}>
+          {s.code.split('\n').map((line, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={i} style={{ color: editorColors.text, whiteSpace: 'pre' }}>
+              {line || ' '}
+            </div>
+          ))}
+        </pre>
+      </Box>
+
+      {/* РЕЗУЛЬТАТ */}
+      {result && (
+        <Box
+          px="md"
+          py={8}
+          style={{
+            borderTop: `1px solid ${editorColors.border}`,
+            background: editorColors.panel,
+            maxHeight: 160,
+            overflow: 'auto',
+            flexShrink: 0,
+          }}
+        >
+          <Group justify="space-between" mb={4}>
+            <Text fz={10} fw={700} c={editorColors.dim} style={{ letterSpacing: 1 }}>
+              РЕЗУЛЬТАТ
+            </Text>
+            <Text fz={10} c={result.exitCode === 0 ? editorColors.ok : editorColors.error}>
+              exit {result.exitCode} · {Math.round(result.durationMs)} мс
+            </Text>
+          </Group>
+          <pre style={{ margin: 0, fontFamily: 'var(--mantine-font-family-monospace)', fontSize: 12, lineHeight: 1.6 }}>
+            {result.lines.length === 0 ? (
+              <span style={{ color: editorColors.dim }}>(нет вывода)</span>
+            ) : (
+              result.lines.map((l, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={i} style={{ color: lineColor(l.type), whiteSpace: 'pre-wrap' }}>
+                  {l.text}
+                </div>
+              ))
+            )}
+          </pre>
+        </Box>
+      )}
+
+      {/* Подпись */}
+      <Group gap={6} px="md" py={6} style={{ borderTop: `1px solid ${frame.border}`, flexShrink: 0 }}>
+        <Text c="blue.6" fz="xs" aria-hidden>
+          ⚡
+        </Text>
+        <Text fz="xs" c={frame.dim}>
+          Работает на Runit
+        </Text>
+      </Group>
+    </Box>
+  );
+}

--- a/frontend/src/v2/pages/Landing/DemoWidget.tsx
+++ b/frontend/src/v2/pages/Landing/DemoWidget.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { Box, Button, Group, Paper, Text, Textarea } from '@mantine/core';
+import { editorColors, langMeta } from '../../theme';
+import { runJavaScript, RunResult } from '../../runner';
+
+const INITIAL_CODE = `// Попробуйте — код выполняется по-настоящему
+const languages = ['JavaScript', 'Python', 'PHP', 'Ruby'];
+
+languages.forEach((lang, i) => {
+  console.log((i + 1) + '. ' + lang);
+});
+
+console.log('…и ещё 6 языков из коробки');`;
+
+function lineColor(type: string): string {
+  switch (type) {
+    case 'error':
+      return editorColors.error;
+    case 'warn':
+      return '#f2c94c';
+    case 'system':
+      return editorColors.dim;
+    default:
+      return editorColors.text;
+  }
+}
+
+// Живой мини-редактор demo.js для лендинга.
+// TODO(#843): заменить Textarea на полноценный CodeMirror с подсветкой синтаксиса,
+// как в основном редакторе.
+export default function DemoWidget() {
+  const [code, setCode] = useState(INITIAL_CODE);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const handleRun = async () => {
+    setRunning(true);
+    try {
+      const res = await runJavaScript(code);
+      setResult(res);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Paper
+        radius="lg"
+        style={{
+          overflow: 'hidden',
+          border: `1px solid ${editorColors.border}`,
+          boxShadow: '0 20px 60px rgba(26, 27, 38, 0.25)',
+        }}
+      >
+        {/* Шапка карточки: имя файла, язык, кнопка запуска */}
+        <Group
+          justify="space-between"
+          px="md"
+          py={10}
+          style={{ background: '#fff', borderBottom: '1px solid #e9ecef' }}
+        >
+          <Group gap={8}>
+            <Text ff="monospace" fz="sm" fw={600} c="dark.9">
+              demo.js
+            </Text>
+            <Box
+              w={8}
+              h={8}
+              style={{ borderRadius: '50%', background: langMeta.javascript.dot }}
+            />
+            <Text fz="sm" c="dimmed">
+              {langMeta.javascript.label}
+            </Text>
+          </Group>
+          <Button
+            size="xs"
+            radius="md"
+            loading={running}
+            onClick={handleRun}
+            leftSection={
+              <svg width={10} height={10} viewBox="0 0 24 24" fill="currentColor">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            }
+          >
+            Запустить
+          </Button>
+        </Group>
+
+        {/* Тёмная область кода */}
+        <Box p="sm" style={{ background: editorColors.bg }}>
+          <Textarea
+            value={code}
+            onChange={(e) => setCode(e.currentTarget.value)}
+            autosize
+            minRows={8}
+            maxRows={16}
+            aria-label="Код demo.js"
+            styles={{
+              input: {
+                background: 'transparent',
+                border: 'none',
+                color: editorColors.text,
+                fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+                fontSize: 14,
+                lineHeight: 1.7,
+                padding: '4px 8px',
+              },
+            }}
+          />
+        </Box>
+
+        {/* Блок результата */}
+        {result && (
+          <Box
+            px="md"
+            py="sm"
+            style={{
+              background: editorColors.panel,
+              borderTop: `1px solid ${editorColors.border}`,
+            }}
+          >
+            <Group justify="space-between" mb={6}>
+              <Text
+                fz={11}
+                fw={700}
+                c={editorColors.dim}
+                style={{ letterSpacing: '0.08em', textTransform: 'uppercase' }}
+              >
+                Результат
+              </Text>
+              <Text fz={11} c={result.exitCode === 0 ? editorColors.ok : editorColors.error}>
+                {result.exitCode === 0 ? 'выполнено' : 'ошибка'} ·{' '}
+                {Math.round(result.durationMs)} мс
+              </Text>
+            </Group>
+            {result.lines.length === 0 ? (
+              <Text ff="monospace" fz={13} c={editorColors.dim}>
+                (нет вывода)
+              </Text>
+            ) : (
+              result.lines.map((line, i) => (
+                <Text
+                  key={i}
+                  ff="monospace"
+                  fz={13}
+                  style={{
+                    color: lineColor(line.type),
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {line.text}
+                </Text>
+              ))
+            )}
+          </Box>
+        )}
+      </Paper>
+
+      <Text ta="center" c="dimmed" fz="sm" mt="sm">
+        Это живой виджет — измените код и нажмите «Запустить»
+      </Text>
+    </Box>
+  );
+}

--- a/frontend/src/v2/pages/Landing/Features.tsx
+++ b/frontend/src/v2/pages/Landing/Features.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react';
+import { Box, Card, SimpleGrid, Text, Title } from '@mantine/core';
+
+type Feature = {
+  title: string;
+  text: string;
+  icon: ReactNode;
+};
+
+function IconBadge({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      w={44}
+      h={44}
+      mb="md"
+      style={{
+        borderRadius: 12,
+        background: 'var(--mantine-color-blue-0)',
+        color: 'var(--mantine-color-blue-6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+const FEATURES: Feature[] = [
+  {
+    title: 'Шаринг по ссылке',
+    text: 'Один клик — и у коллеги та же версия, тот же результат. Без «пришли файлом» и скриншотов кода.',
+    icon: (
+      <svg
+        width={22}
+        height={22}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Встраивание на сайты',
+    text: 'Живой сниппет в статье или уроке: читатель меняет код и запускает его, не покидая страницу.',
+    icon: (
+      <svg
+        width={22}
+        height={22}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Совместное редактирование',
+    text: 'Работайте над одним сниппетом всей командой: курсоры участников видны в реальном времени.',
+    icon: (
+      <svg
+        width={22}
+        height={22}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx={9} cy={7} r={4} />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    ),
+  },
+];
+
+export default function Features() {
+  return (
+    <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="lg">
+      {FEATURES.map((f) => (
+        <Card key={f.title} padding="xl" radius="lg" withBorder>
+          <IconBadge>{f.icon}</IconBadge>
+          <Title order={3} fz="lg" mb={6}>
+            {f.title}
+          </Title>
+          <Text c="dimmed" fz="sm" lh={1.6}>
+            {f.text}
+          </Text>
+        </Card>
+      ))}
+    </SimpleGrid>
+  );
+}

--- a/frontend/src/v2/pages/Landing/Languages.tsx
+++ b/frontend/src/v2/pages/Landing/Languages.tsx
@@ -1,0 +1,51 @@
+import { Box, Group, Text, Title } from '@mantine/core';
+import { langMeta } from '../../theme';
+
+// Чипы «10 языков — из коробки». В MVP реально исполняется только JavaScript,
+// остальные чипы — просто витрина (это ок по макету).
+// TODO(#843): когда появится серверное исполнение (#821), пометить runnable-языки.
+const LANGS: { label: string; dot: string }[] = [
+  { label: 'JavaScript', dot: langMeta.javascript.dot },
+  { label: 'TypeScript', dot: langMeta.typescript.dot },
+  { label: 'Python', dot: langMeta.python.dot },
+  { label: 'PHP', dot: langMeta.php.dot },
+  { label: 'Ruby', dot: langMeta.ruby.dot },
+  { label: 'Java', dot: langMeta.java.dot },
+  { label: 'Go', dot: '#00ADD8' },
+  { label: 'C++', dot: '#f34b7d' },
+  { label: 'SQL', dot: '#e38c00' },
+  { label: 'Bash', dot: '#89e051' },
+];
+
+export default function Languages() {
+  return (
+    <Box ta="center">
+      <Title order={2} fz={{ base: 26, sm: 32 }} mb="xs">
+        10 языков — из коробки
+      </Title>
+      <Text c="dimmed" mb="xl">
+        Выбирайте язык при создании сниппета — окружение уже настроено.
+      </Text>
+      <Group justify="center" gap="sm">
+        {LANGS.map((lang) => (
+          <Group
+            key={lang.label}
+            gap={8}
+            px={16}
+            py={8}
+            style={{
+              border: '1px solid #e9ecef',
+              borderRadius: 999,
+              background: '#fff',
+            }}
+          >
+            <Box w={8} h={8} style={{ borderRadius: '50%', background: lang.dot }} />
+            <Text fz="sm" fw={500}>
+              {lang.label}
+            </Text>
+          </Group>
+        ))}
+      </Group>
+    </Box>
+  );
+}

--- a/frontend/src/v2/pages/Landing/index.tsx
+++ b/frontend/src/v2/pages/Landing/index.tsx
@@ -1,0 +1,110 @@
+import { Link } from 'react-router-dom';
+import {
+  Badge,
+  Box,
+  Button,
+  Container,
+  Group,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import AppHeader from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+import DemoWidget from './DemoWidget';
+import Features from './Features';
+import Languages from './Languages';
+
+export default function Landing() {
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+
+      <Box component="main" style={{ flex: 1, background: '#f8f9fa' }}>
+        {/* HERO */}
+        <Container size="lg" py={{ base: 48, sm: 72 }}>
+          <Stack align="center" gap="lg">
+            <Badge
+              size="lg"
+              variant="light"
+              radius="xl"
+              px={16}
+              style={{ textTransform: 'none', fontWeight: 500 }}
+              leftSection={
+                <svg width={12} height={12} viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" />
+                </svg>
+              }
+            >
+              Используется на платформах Хекслета
+            </Badge>
+
+            <Title
+              order={1}
+              ta="center"
+              fz={{ base: 38, sm: 56 }}
+              lh={1.1}
+              maw={760}
+            >
+              Пишите и запускайте код{' '}
+              <Text span inherit c="blue.6">
+                прямо в браузере
+              </Text>
+            </Title>
+
+            <Text ta="center" c="dimmed" fz={{ base: 'md', sm: 'lg' }} maw={640} lh={1.6}>
+              Runit — среда для написания и выполнения кода. Делитесь по ссылке,
+              встраивайте живые сниппеты в статьи и уроки, редактируйте вместе —
+              в реальном времени.
+            </Text>
+
+            <Group gap="md" justify="center">
+              <Button size="lg" component={Link} to="/editor">
+                Создать сниппет
+              </Button>
+              {/* TODO(#843): страница «Как это встраивается» (гайд по embed) ещё не готова */}
+              <Tooltip label="В разработке (#843)">
+                <Button size="lg" variant="light" data-disabled onClick={(e) => e.preventDefault()}>
+                  Как это встраивается →
+                </Button>
+              </Tooltip>
+            </Group>
+
+            {/* Живой мини-редактор */}
+            <Box w="100%" maw={780} mt="xl">
+              <DemoWidget />
+            </Box>
+          </Stack>
+        </Container>
+
+        {/* ФИЧИ */}
+        <Container size="lg" py={{ base: 32, sm: 48 }}>
+          <Features />
+        </Container>
+
+        {/* ЯЗЫКИ */}
+        <Container size="lg" py={{ base: 32, sm: 48 }}>
+          <Languages />
+        </Container>
+
+        {/* ФИНАЛЬНЫЙ CTA */}
+        <Container size="lg" py={{ base: 48, sm: 72 }}>
+          <Stack align="center" gap="md">
+            <Title order={2} ta="center" fz={{ base: 26, sm: 32 }}>
+              Готовы попробовать?
+            </Title>
+            <Text ta="center" c="dimmed" maw={520}>
+              Создайте первый сниппет за минуту — без установки и настройки окружения.
+            </Text>
+            <Button size="lg" component={Link} to="/editor">
+              Создать сниппет
+            </Button>
+          </Stack>
+        </Container>
+      </Box>
+
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Legal/index.tsx
+++ b/frontend/src/v2/pages/Legal/index.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Container,
+  Group,
+  Paper,
+  Stack,
+  Tabs,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import AppHeader from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+
+type LegalTab = 'terms' | 'privacy';
+
+function LegalSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Box>
+      <Title order={4} mb={6}>
+        {title}
+      </Title>
+      <Text c="dark.6" style={{ lineHeight: 1.65 }}>
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
+const termsSections: Array<{ title: string; body: string }> = [
+  {
+    title: '1. О сервисе',
+    body:
+      'Runit («Сервис») — среда для написания, выполнения и распространения кода: сниппеты ' +
+      'можно редактировать онлайн, публиковать по ссылке и встраивать на сторонние сайты. ' +
+      'Правообладатель Сервиса — ООО «Хекслет Рус».',
+  },
+  {
+    title: '2. Аккаунт',
+    body:
+      'Для сохранения сниппетов, шаринга и совместного редактирования нужна учётная запись. ' +
+      'Вы отвечаете за сохранность данных для входа и за действия, совершённые в вашем аккаунте.',
+  },
+  {
+    title: '3. Ваш контент',
+    body:
+      'Права на код остаются за вами. Публикуя сниппет по ссылке или через виджет встраивания, ' +
+      'вы разрешаете неограниченному кругу лиц просматривать, запускать и форкать его.',
+  },
+  {
+    title: '4. Ограничения',
+    body:
+      'Запрещено использовать среду выполнения для вредоносного кода, майнинга, сетевых атак ' +
+      'и обхода ресурсных лимитов. Нарушение ведёт к блокировке сниппета или аккаунта.',
+  },
+  {
+    title: '5. Гарантии и ответственность',
+    body:
+      'Сервис предоставляется «как есть». Мы стремимся к непрерывной доступности, но не ' +
+      'отвечаем за убытки из-за перерывов в работе. Ответственность Сервиса в любом случае ' +
+      'ограничена суммой, фактически уплаченной вами за использование Сервиса. ' +
+      'Вопросы — support@hexlet.io.',
+  },
+];
+
+const privacySections: Array<{ title: string; body: string }> = [
+  {
+    title: '1. Какие данные мы храним',
+    body:
+      'Мы храним минимум: адрес электронной почты, имя пользователя и созданные вами сниппеты ' +
+      '(код, название, язык, даты изменений). Платёжные данные и телефон мы не запрашиваем.',
+  },
+  {
+    title: '2. Cookies и сессии',
+    body:
+      'Cookies используются только для поддержания сессии входа и запоминания настроек ' +
+      'интерфейса. Рекламных и сторонних трекинговых cookies Сервис не устанавливает.',
+  },
+  {
+    title: '3. Кому мы не передаём данные',
+    body:
+      'Мы не продаём и не передаём ваши данные третьим лицам, за исключением случаев, прямо ' +
+      'предусмотренных законодательством. Публичными являются только сниппеты, которыми вы ' +
+      'сами поделились по ссылке.',
+  },
+  {
+    title: '4. Ваши права',
+    body:
+      'Вы можете в любой момент изменить или удалить свои сниппеты, а также удалить аккаунт ' +
+      'целиком — вместе с ним будут удалены все связанные данные.',
+  },
+  {
+    title: '5. Контакт',
+    body:
+      'По вопросам обработки персональных данных пишите на support@hexlet.io — ответим ' +
+      'в течение 10 рабочих дней.',
+  },
+];
+
+export default function LegalPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawTab = searchParams.get('tab');
+  const tab: LegalTab = rawTab === 'privacy' ? 'privacy' : 'terms';
+
+  const handleTabChange = (value: string | null) => {
+    const next: LegalTab = value === 'privacy' ? 'privacy' : 'terms';
+    setSearchParams(next === 'terms' ? {} : { tab: next }, { replace: true });
+  };
+
+  const sections = tab === 'privacy' ? privacySections : termsSections;
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+      <Container size="lg" py={40} style={{ flex: 1, width: '100%' }}>
+        <Box maw={900} mx="auto">
+          <Group justify="space-between" align="flex-start" wrap="wrap">
+            <Box>
+              <Title order={1}>Правовая информация</Title>
+              <Text c="dimmed" mt={4}>
+                Редакция от 12 мая 2026 года · ООО «Хекслет Рус»
+              </Text>
+            </Box>
+            {/* TODO(#844): экспорт правовых документов в PDF (генерация на бэкенде). */}
+            <Tooltip label="В разработке (#844)">
+              <Button variant="light" color="gray" data-disabled onClick={(e) => e.preventDefault()}>
+                Скачать PDF
+              </Button>
+            </Tooltip>
+          </Group>
+
+          <Tabs value={tab} onChange={handleTabChange} mt="xl">
+            <Tabs.List>
+              <Tabs.Tab value="terms">Условия использования</Tabs.Tab>
+              <Tabs.Tab value="privacy">Конфиденциальность</Tabs.Tab>
+            </Tabs.List>
+          </Tabs>
+
+          <Paper withBorder radius="lg" p={{ base: 'lg', sm: 36 }} mt="lg">
+            <Stack gap="xl">
+              {sections.map((s) => (
+                <LegalSection key={s.title} title={s.title}>
+                  {s.body}
+                </LegalSection>
+              ))}
+            </Stack>
+          </Paper>
+        </Box>
+      </Container>
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/NotFound/index.tsx
+++ b/frontend/src/v2/pages/NotFound/index.tsx
@@ -1,0 +1,75 @@
+import { Link } from 'react-router-dom';
+import { Box, Button, Container, Group, Stack, Text, Title } from '@mantine/core';
+import AppHeader from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+import { editorColors } from '../../theme';
+
+// TODO(#845): логировать 404-переходы и предлагать похожие публичные сниппеты
+// (поиск по slug через trpc.snippets.getAllSnippets + fuzzy-match).
+
+function TerminalCard() {
+  return (
+    <Box
+      p="xl"
+      maw={720}
+      w="100%"
+      style={{
+        background: editorColors.bg,
+        border: `1px solid ${editorColors.border}`,
+        borderRadius: 16,
+        fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+        fontSize: 15,
+        lineHeight: 2,
+        textAlign: 'left',
+      }}
+    >
+      <Text ff="inherit" fz="inherit" style={{ color: editorColors.accent }}>
+        $ runit open s/xK91q
+      </Text>
+      <Text ff="inherit" fz="inherit" style={{ color: editorColors.error }}>
+        Ошибка 404: сниппет не найден
+      </Text>
+      <Text ff="inherit" fz="inherit" style={{ color: editorColors.dim }}>
+        Процесс завершился с кодом 1
+      </Text>
+    </Box>
+  );
+}
+
+export default function NotFoundPage() {
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+      <Container
+        size="lg"
+        style={{
+          flex: 1,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Stack align="center" gap="lg" py={60}>
+          <TerminalCard />
+          <Title order={2} ta="center" mt="sm">
+            Такой страницы нет
+          </Title>
+          <Text c="dimmed" ta="center" maw={520}>
+            Возможно, автор сделал сниппет приватным, переименовал или удалил его. Проверьте
+            ссылку — или начните с чистого листа.
+          </Text>
+          <Group gap="sm">
+            <Button component={Link} to="/">
+              На главную
+            </Button>
+            <Button component={Link} to="/snippets" variant="light">
+              Мои сниппеты
+            </Button>
+          </Group>
+        </Stack>
+      </Container>
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Profile/index.tsx
+++ b/frontend/src/v2/pages/Profile/index.tsx
@@ -1,0 +1,257 @@
+import type { ReactNode } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPCClient } from '../../../utils/trpc';
+import { useSession } from '../../session';
+import { langMeta } from '../../theme';
+import AppHeader, { initialsOf } from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+
+type Snippet = {
+  id: number;
+  name: string;
+  slug: string;
+  code: string;
+  language: string;
+  userId: number;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+};
+
+const MONTHS_GENITIVE = [
+  'января',
+  'февраля',
+  'марта',
+  'апреля',
+  'мая',
+  'июня',
+  'июля',
+  'августа',
+  'сентября',
+  'октября',
+  'ноября',
+  'декабря',
+];
+
+// «В Runit с марта 2024»
+function sinceLabel(date: Date): string {
+  if (Number.isNaN(date.getTime()) || date.getTime() === 0) return 'недавнего времени';
+  return `${MONTHS_GENITIVE[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+// Простая относительная дата для карточек: «2 часа назад», «вчера», «12 мая 2026»
+function relativeDate(value: string | Date): string {
+  if (!value) return 'недавно';
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  const hour = 3600_000;
+  const day = 24 * hour;
+  if (diffMs < hour) return 'только что';
+  if (diffMs < day) {
+    const h = Math.floor(diffMs / hour);
+    const mod10 = h % 10;
+    const mod100 = h % 100;
+    let word = 'часов';
+    if (mod10 === 1 && mod100 !== 11) word = 'час';
+    else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) word = 'часа';
+    return `${h} ${word} назад`;
+  }
+  if (diffMs < 2 * day) return 'вчера';
+  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)} дн. назад`;
+  return `${date.getDate()} ${MONTHS_GENITIVE[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+function SnippetCard({ snippet, username }: { snippet: Snippet; username: string }) {
+  const meta = langMeta[snippet.language] ?? {
+    label: snippet.language,
+    dot: '#adb5bd',
+    runnable: false,
+  };
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p="lg"
+      component={Link}
+      to={`/s/${username}/${snippet.slug}`}
+      style={{ textDecoration: 'none', color: 'inherit' }}
+    >
+      <Group justify="space-between" wrap="nowrap" mb="sm">
+        <Group gap={8} wrap="nowrap" style={{ minWidth: 0 }}>
+          <Box
+            w={10}
+            h={10}
+            style={{ borderRadius: '50%', background: meta.dot, flexShrink: 0 }}
+          />
+          <Text ff="monospace" fw={600} truncate>
+            {snippet.name}
+          </Text>
+        </Group>
+        <Text c="dimmed" fz="sm" style={{ flexShrink: 0 }}>
+          {meta.label}
+        </Text>
+      </Group>
+      <Group justify="space-between" mt="md">
+        <Text c="dimmed" fz="sm">
+          {relativeDate(snippet.updatedAt ?? snippet.createdAt)}
+        </Text>
+        {/* TODO(#828): счётчики просмотров и форков сниппета */}
+        <Text c="dimmed" fz="sm">
+          — просмотров · — форков
+        </Text>
+      </Group>
+    </Card>
+  );
+}
+
+function NotFoundState({ username }: { username: string }) {
+  return (
+    <Center py={80}>
+      <Stack align="center" gap="sm">
+        <Title order={2}>Пользователь не найден</Title>
+        <Text c="dimmed" ta="center">
+          Профиля @{username} не существует или он был удалён.
+        </Text>
+        <Button component={Link} to="/" mt="sm">
+          На главную
+        </Button>
+      </Stack>
+    </Center>
+  );
+}
+
+export default function Profile() {
+  const { username = '' } = useParams();
+  const trpc = useTRPCClient();
+  const { user: me } = useSession();
+
+  const userQuery = useQuery({
+    queryKey: ['v2', 'user', username],
+    queryFn: () => trpc.users.getUserByUsername.query(username),
+    retry: false,
+  });
+
+  const profileUser = userQuery.data ?? null;
+
+  const snippetsQuery = useQuery({
+    queryKey: ['v2', 'profileSnippets', profileUser?.id],
+    queryFn: async () => {
+      const all = (await trpc.snippets.getAllSnippets.query()) as Snippet[];
+      return all.filter((s) => s.userId === profileUser!.id);
+    },
+    enabled: !!profileUser,
+  });
+
+  const snippets = snippetsQuery.data ?? [];
+  const isOwn = !!me && !!profileUser && me.id === profileUser.id;
+
+  let content: ReactNode;
+  if (userQuery.isLoading) {
+    content = (
+      <Center py={80}>
+        <Loader />
+      </Center>
+    );
+  } else if (userQuery.isError || !profileUser) {
+    content = <NotFoundState username={username} />;
+  } else {
+    content = (
+      <>
+        <Group align="flex-start" justify="space-between" wrap="nowrap" py="xl">
+          <Group align="flex-start" gap="xl" wrap="nowrap">
+            <Avatar color="blue" variant="filled" radius="50%" size={110}>
+              <Text fz={36} fw={700} c="inherit">
+                {initialsOf(profileUser.username)}
+              </Text>
+            </Avatar>
+            <Stack gap={6}>
+              <Title order={1}>{profileUser.username}</Title>
+              <Text c="dimmed">@{profileUser.username}</Text>
+              <Text c="dimmed" fz="sm">
+                В Runit с {sinceLabel(new Date(profileUser.createdAt ?? NaN))}
+              </Text>
+            </Stack>
+          </Group>
+          {isOwn && (
+            <Button variant="default" component={Link} to="/settings">
+              Настроить профиль
+            </Button>
+          )}
+        </Group>
+
+        <Divider />
+
+        {/* TODO(#828): реальные счётчики просмотров и форков */}
+        <Group gap={48} py="lg">
+          <Group gap={8} align="baseline">
+            <Text fw={800} fz={26}>
+              {snippets.length}
+            </Text>
+            <Text c="dimmed">сниппетов</Text>
+          </Group>
+          <Group gap={8} align="baseline">
+            <Text fw={800} fz={26}>
+              —
+            </Text>
+            <Text c="dimmed">просмотров</Text>
+          </Group>
+          <Group gap={8} align="baseline">
+            <Text fw={800} fz={26}>
+              —
+            </Text>
+            <Text c="dimmed">форков</Text>
+          </Group>
+        </Group>
+
+        <Title order={3} mb="md">
+          Публичные сниппеты
+        </Title>
+        {snippetsQuery.isLoading ? (
+          <Center py={40}>
+            <Loader size="sm" />
+          </Center>
+        ) : snippets.length === 0 ? (
+          <Card withBorder radius="lg" p="xl">
+            <Stack align="center" gap={4} py="lg">
+              <Text fw={600}>Пока нет публичных сниппетов</Text>
+              <Text c="dimmed" fz="sm" ta="center">
+                Когда @{profileUser.username} опубликует сниппеты, они появятся здесь.
+              </Text>
+            </Stack>
+          </Card>
+        ) : (
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
+            {snippets.map((s) => (
+              <SnippetCard key={s.id} snippet={s} username={profileUser.username} />
+            ))}
+          </SimpleGrid>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+      <Container size="lg" py="xl" style={{ width: '100%', flex: 1 }}>
+        {content}
+      </Container>
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Settings/index.tsx
+++ b/frontend/src/v2/pages/Settings/index.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Container,
+  Divider,
+  Group,
+  Modal,
+  SegmentedControl,
+  Slider,
+  Stack,
+  Switch,
+  Tabs,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { useMutation } from '@tanstack/react-query';
+import { useSession } from '../../session';
+import { useTRPCClient } from '../../../utils/trpc';
+import AppHeader, { initialsOf } from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+
+// Ключи localStorage для настроек редактора.
+// TODO(#832): перенести настройки на сервер (users.settings), сейчас — только localStorage.
+const LS_FONT_SIZE = 'runit.v2.editorFontSize';
+const LS_CONSOLE_LAYOUT = 'runit.v2.consoleLayout';
+const LS_TAB_SPACES = 'runit.v2.tabSpaces';
+
+const readLS = (key: string, fallback: string): string => {
+  try {
+    return localStorage.getItem(key) ?? fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+// Строка-настройка в стиле макета: заголовок + подпись слева, контрол справа.
+function SettingRow({
+  title,
+  description,
+  control,
+}: {
+  title: string;
+  description: string;
+  control: ReactNode;
+}) {
+  return (
+    <Group justify="space-between" wrap="nowrap" align="center" py="md">
+      <Box>
+        <Text fw={600}>{title}</Text>
+        <Text c="dimmed" fz="sm">
+          {description}
+        </Text>
+      </Box>
+      {control}
+    </Group>
+  );
+}
+
+function ProfileTab() {
+  const { user } = useSession();
+  const [name, setName] = useState('');
+  const [username, setUsername] = useState(user?.username ?? '');
+  const [about, setAbout] = useState('');
+
+  return (
+    <Card withBorder radius="lg" p="xl" mt="lg">
+      <Stack gap="lg">
+        <Group gap="lg">
+          <Avatar color="blue" radius="xl" size={72}>
+            {initialsOf(user?.username ?? '')}
+          </Avatar>
+          <Group gap="sm">
+            {/* TODO(#536): загрузка аватара (сейчас — только инициалы) */}
+            <Tooltip label="В разработке (#536)">
+              <Button
+                variant="default"
+                data-disabled
+                onClick={(e) => e.preventDefault()}
+              >
+                Загрузить фото
+              </Button>
+            </Tooltip>
+            <Tooltip label="В разработке (#536)">
+              <Button
+                variant="subtle"
+                color="red"
+                data-disabled
+                onClick={(e) => e.preventDefault()}
+              >
+                Удалить
+              </Button>
+            </Tooltip>
+          </Group>
+        </Group>
+
+        <TextInput
+          label="Имя"
+          placeholder="Как вас зовут"
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+        />
+        <TextInput
+          label="Имя пользователя"
+          leftSection={
+            <Text fz="sm" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+              runit.hexlet.io/@
+            </Text>
+          }
+          leftSectionWidth={140}
+          styles={{ input: { paddingLeft: 140 } }}
+          value={username}
+          onChange={(e) => setUsername(e.currentTarget.value)}
+        />
+        <Textarea
+          label="О себе"
+          placeholder="Пара слов о том, чем занимаетесь"
+          minRows={3}
+          autosize
+          value={about}
+          onChange={(e) => setAbout(e.currentTarget.value)}
+        />
+
+        <Group justify="flex-end">
+          {/* TODO(#718, #832): сохранение профиля (имя, био) на сервере */}
+          <Tooltip label="В разработке (#718/#832)">
+            <Button data-disabled onClick={(e) => e.preventDefault()}>
+              Сохранить
+            </Button>
+          </Tooltip>
+        </Group>
+      </Stack>
+    </Card>
+  );
+}
+
+function EditorTab() {
+  const [fontSize, setFontSize] = useState<number>(() => {
+    const parsed = Number(readLS(LS_FONT_SIZE, '14'));
+    return Number.isFinite(parsed) && parsed >= 12 && parsed <= 20 ? parsed : 14;
+  });
+  const [consoleLayout, setConsoleLayout] = useState<string>(() =>
+    readLS(LS_CONSOLE_LAYOUT, 'right'),
+  );
+  const [tabSpaces, setTabSpaces] = useState<boolean>(
+    () => readLS(LS_TAB_SPACES, 'true') === 'true',
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_FONT_SIZE, String(fontSize));
+    } catch {
+      /* приватный режим — молча пропускаем */
+    }
+  }, [fontSize]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_CONSOLE_LAYOUT, consoleLayout);
+    } catch {
+      /* noop */
+    }
+  }, [consoleLayout]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_TAB_SPACES, String(tabSpaces));
+    } catch {
+      /* noop */
+    }
+  }, [tabSpaces]);
+
+  return (
+    <Card withBorder radius="lg" p="xl" mt="lg">
+      <SettingRow
+        title="Размер шрифта в редакторе"
+        description="Применяется мгновенно"
+        control={
+          <Group gap="md" wrap="nowrap" w={320}>
+            <Slider
+              min={12}
+              max={20}
+              step={1}
+              value={fontSize}
+              onChange={setFontSize}
+              style={{ flex: 1 }}
+              label={(v) => `${v} px`}
+            />
+            <Badge variant="light" size="lg" radius="sm">
+              {fontSize} px
+            </Badge>
+          </Group>
+        }
+      />
+      <Divider />
+      <SettingRow
+        title="Расположение консоли"
+        description="Справа — как в repl.it, снизу — как в IDE"
+        control={
+          <SegmentedControl
+            value={consoleLayout}
+            onChange={setConsoleLayout}
+            data={[
+              { label: 'Справа', value: 'right' },
+              { label: 'Снизу', value: 'bottom' },
+            ]}
+          />
+        }
+      />
+      <Divider />
+      <SettingRow
+        title="Табуляция"
+        description="Клавиша Tab вставляет пробелы"
+        control={
+          <Switch
+            size="md"
+            checked={tabSpaces}
+            onChange={(e) => setTabSpaces(e.currentTarget.checked)}
+          />
+        }
+      />
+      <Text c="dimmed" fz="sm" ta="center" mt="lg">
+        Размер шрифта и расположение консоли уже применены к редактору — откройте его,
+        чтобы проверить.
+      </Text>
+    </Card>
+  );
+}
+
+function AccountTab() {
+  const { user, logout } = useSession();
+  const trpc = useTRPCClient();
+  const navigate = useNavigate();
+  const [confirmOpened, setConfirmOpened] = useState(false);
+
+  const deleteMutation = useMutation({
+    // TODO(#834): каскадная очистка сниппетов пользователя при удалении аккаунта.
+    mutationFn: () => trpc.users.deleteUser.mutate({ id: user!.id }),
+    onSuccess: () => {
+      notifications.show({ message: 'Аккаунт удалён', color: 'gray' });
+      logout();
+      navigate('/');
+    },
+    onError: () => {
+      notifications.show({
+        message: 'Не удалось удалить аккаунт. Попробуйте позже.',
+        color: 'red',
+      });
+    },
+  });
+
+  return (
+    <Stack gap="lg" mt="lg">
+      <Card withBorder radius="lg" p="xl">
+        <Text fw={600} mb="md">
+          Электронная почта
+        </Text>
+        <Group justify="space-between" wrap="nowrap">
+          <Group gap="sm">
+            <Text>{user?.email}</Text>
+            {/* TODO(#416, #472): реальное подтверждение почты письмом */}
+            <Badge variant="light" color="gray">
+              Подтверждена
+            </Badge>
+          </Group>
+          <Tooltip label="В разработке (#416/#472)">
+            <Button variant="default" data-disabled onClick={(e) => e.preventDefault()}>
+              Сменить
+            </Button>
+          </Tooltip>
+        </Group>
+      </Card>
+
+      <Card withBorder radius="lg" p="xl">
+        <Text fw={600} mb="md">
+          Пароль
+        </Text>
+        <Group justify="space-between" wrap="nowrap">
+          <Text c="dimmed" fz="sm">
+            Регулярная смена пароля повышает безопасность аккаунта.
+          </Text>
+          {/* TODO(#770, #640): смена пароля через бэкенд */}
+          <Tooltip label="В разработке (#770/#640)">
+            <Button variant="default" data-disabled onClick={(e) => e.preventDefault()}>
+              Сменить пароль
+            </Button>
+          </Tooltip>
+        </Group>
+      </Card>
+
+      <Card withBorder radius="lg" p="xl">
+        <Text fw={600} mb="md">
+          Активные сессии
+        </Text>
+        <Group justify="space-between">
+          <Text>Этот браузер</Text>
+          <Badge variant="light" color="green">
+            Текущая
+          </Badge>
+        </Group>
+        {/* TODO(#833): список активных сессий с бэкенда */}
+        <Text c="dimmed" fz="sm" mt="sm">
+          Список сессий появится позже (#833)
+        </Text>
+      </Card>
+
+      <Card
+        withBorder
+        radius="lg"
+        p="xl"
+        style={{ borderColor: 'var(--mantine-color-red-3)' }}
+      >
+        <Text fw={600} c="red.7" mb="md">
+          Удаление аккаунта
+        </Text>
+        <Group justify="space-between" wrap="nowrap" align="center">
+          <Text c="dimmed" fz="sm">
+            Аккаунт и все сниппеты будут удалены безвозвратно. Это действие нельзя
+            отменить.
+          </Text>
+          <Button color="red" variant="outline" onClick={() => setConfirmOpened(true)}>
+            Удалить аккаунт
+          </Button>
+        </Group>
+      </Card>
+
+      <Modal
+        opened={confirmOpened}
+        onClose={() => setConfirmOpened(false)}
+        title="Удалить аккаунт?"
+        centered
+        radius="lg"
+      >
+        <Text fz="sm" mb="lg">
+          Аккаунт <b>@{user?.username}</b> и все его сниппеты будут удалены
+          безвозвратно. Это действие нельзя отменить.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={() => setConfirmOpened(false)}>
+            Отмена
+          </Button>
+          <Button
+            color="red"
+            loading={deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate()}
+          >
+            Удалить навсегда
+          </Button>
+        </Group>
+      </Modal>
+    </Stack>
+  );
+}
+
+export default function Settings() {
+  const { isGuest } = useSession();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isGuest) navigate('/', { replace: true });
+  }, [isGuest, navigate]);
+
+  if (isGuest) return null;
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader />
+      <Container size="lg" py="xl" style={{ width: '100%' }}>
+        <Box maw={760} mx="auto">
+          <Title order={1} mb="lg">
+            Настройки
+          </Title>
+          <Tabs defaultValue="profile">
+            <Tabs.List>
+              <Tabs.Tab value="profile">Профиль</Tabs.Tab>
+              <Tabs.Tab value="editor">Редактор</Tabs.Tab>
+              <Tabs.Tab value="account">Аккаунт</Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panel value="profile">
+              <ProfileTab />
+            </Tabs.Panel>
+            <Tabs.Panel value="editor">
+              <EditorTab />
+            </Tabs.Panel>
+            <Tabs.Panel value="account">
+              <AccountTab />
+            </Tabs.Panel>
+          </Tabs>
+        </Box>
+      </Container>
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/Share/index.tsx
+++ b/frontend/src/v2/pages/Share/index.tsx
@@ -1,0 +1,399 @@
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  Anchor,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Center,
+  Container,
+  CopyButton,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useTRPCClient } from '../../../utils/trpc';
+import { editorColors, langMeta } from '../../theme';
+import { runJavaScript, unsupportedLanguage, type RunResult } from '../../runner';
+import { useSession } from '../../session';
+import { useAuthModal } from '../../components/AuthModal/context';
+import AppHeader, { initialsOf } from '../../components/AppHeader';
+import AppFooter from '../../components/AppFooter';
+
+type Snippet = {
+  id: number;
+  name: string;
+  slug: string;
+  code: string;
+  language: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const EXT: Record<string, string> = {
+  javascript: 'js',
+  python: 'py',
+  php: 'php',
+  ruby: 'rb',
+  java: 'java',
+  html: 'html',
+};
+
+export function fileNameOf(snippet: Pick<Snippet, 'name' | 'language'>): string {
+  return `${snippet.name}.${EXT[snippet.language] ?? 'txt'}`;
+}
+
+// Относительная дата по-русски (упрощённо, без библиотек).
+export function relativeDate(iso: string): string {
+  if (!iso) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'недавно';
+  const days = Math.floor((Date.now() - then) / (24 * 60 * 60 * 1000));
+  if (days <= 0) return 'сегодня';
+  if (days === 1) return 'вчера';
+  if (days < 7) return `${days} дн. назад`;
+  return new Date(iso).toLocaleDateString('ru-RU');
+}
+
+function lineColor(type: string): string {
+  if (type === 'error') return editorColors.error;
+  if (type === 'warn') return '#e5c07b';
+  if (type === 'system') return editorColors.dim;
+  return editorColors.text;
+}
+
+// Тёмная карточка кода: заголовок файла, read-only листинг, «Запустить», РЕЗУЛЬТАТ.
+function CodeCard({
+  snippet,
+  onOpenEditor,
+}: {
+  snippet: Snippet;
+  onOpenEditor: () => void;
+}) {
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const meta = langMeta[snippet.language];
+
+  const run = async () => {
+    if (!meta?.runnable) {
+      setResult(unsupportedLanguage(meta?.label ?? snippet.language));
+      return;
+    }
+    setRunning(true);
+    try {
+      setResult(await runJavaScript(snippet.code));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <Box
+      style={{
+        borderRadius: 16,
+        overflow: 'hidden',
+        border: `1px solid ${editorColors.border}`,
+        background: editorColors.bg,
+      }}
+    >
+      <Group
+        justify="space-between"
+        px="lg"
+        py="sm"
+        style={{ background: editorColors.panel, borderBottom: `1px solid ${editorColors.border}` }}
+      >
+        <Text ff="monospace" fz="sm" c={editorColors.text}>
+          {fileNameOf(snippet)}
+        </Text>
+        <Button size="xs" onClick={run} loading={running} leftSection={<span aria-hidden>▶</span>}>
+          Запустить
+        </Button>
+      </Group>
+
+      <Box px="lg" py="md" style={{ overflowX: 'auto' }}>
+        <pre style={{ margin: 0, fontFamily: 'var(--mantine-font-family-monospace)', fontSize: 14, lineHeight: 1.7 }}>
+          {snippet.code.split('\n').map((line, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={i} style={{ display: 'flex', gap: 20 }}>
+              <span style={{ color: editorColors.dim, minWidth: 24, textAlign: 'right', userSelect: 'none' }}>
+                {i + 1}
+              </span>
+              <span style={{ color: editorColors.text, whiteSpace: 'pre' }}>{line || ' '}</span>
+            </div>
+          ))}
+        </pre>
+      </Box>
+
+      {result && (
+        <Box px="lg" py="md" style={{ borderTop: `1px solid ${editorColors.border}`, background: editorColors.panel }}>
+          <Group justify="space-between" mb={6}>
+            <Text fz="xs" fw={700} c={editorColors.dim} style={{ letterSpacing: 1 }}>
+              РЕЗУЛЬТАТ
+            </Text>
+            <Text fz="xs" c={result.exitCode === 0 ? editorColors.ok : editorColors.error}>
+              exit {result.exitCode} · {Math.round(result.durationMs)} мс
+            </Text>
+          </Group>
+          <pre style={{ margin: 0, fontFamily: 'var(--mantine-font-family-monospace)', fontSize: 13, lineHeight: 1.6 }}>
+            {result.lines.length === 0 ? (
+              <span style={{ color: editorColors.dim }}>(нет вывода)</span>
+            ) : (
+              result.lines.map((l, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={i} style={{ color: lineColor(l.type), whiteSpace: 'pre-wrap' }}>
+                  {l.text}
+                </div>
+              ))
+            )}
+          </pre>
+        </Box>
+      )}
+
+      <Group
+        justify="space-between"
+        px="lg"
+        py="sm"
+        style={{ background: '#fff', borderTop: `1px solid ${editorColors.border}` }}
+      >
+        <Group gap={6}>
+          <Text c="blue.6" fz="sm" aria-hidden>
+            ⚡
+          </Text>
+          <Text fz="sm" c="dimmed">
+            Работает на Runit
+          </Text>
+        </Group>
+        <Anchor component="button" type="button" fz="sm" fw={600} onClick={onOpenEditor}>
+          Открыть в редакторе →
+        </Anchor>
+      </Group>
+    </Box>
+  );
+}
+
+function NotFoundState() {
+  return (
+    <Center py={120}>
+      <Stack align="center" gap="md">
+        <Title order={2}>Сниппет не найден</Title>
+        <Text c="dimmed">Возможно, ссылка устарела или сниппет был удалён.</Text>
+        <Button component={Link} to="/">
+          На главную
+        </Button>
+      </Stack>
+    </Center>
+  );
+}
+
+export default function Share() {
+  const { username = '', slug = '' } = useParams();
+  const navigate = useNavigate();
+  const trpc = useTRPCClient();
+  const { user, isGuest } = useSession();
+  const auth = useAuthModal();
+
+  const { data: snippet, isLoading, isError } = useQuery({
+    queryKey: ['v2', 'snippet-by-slug', username, slug],
+    queryFn: () => trpc.snippets.getSnippetByUsernameSlug.query({ username, slug }),
+    retry: false,
+  });
+
+  const forkMutation = useMutation({
+    mutationFn: async (s: Snippet) =>
+      trpc.snippets.createSnippet.mutate({
+        name: `${s.name}-fork`,
+        code: s.code,
+        language: s.language,
+        userId: user!.id,
+      }),
+    onSuccess: (created: { id: number }) => navigate(`/editor/${created.id}`),
+  });
+
+  const handleFork = () => {
+    if (isGuest) {
+      auth.open('register');
+      return;
+    }
+    if (snippet) forkMutation.mutate(snippet as Snippet);
+  };
+
+  const meta = snippet ? langMeta[(snippet as Snippet).language] : null;
+  const shareUrl = `runit.hexlet.io/s/${username}/${slug}`;
+
+  const embedCode = snippet
+    ? `<iframe src="${window.location.origin}/embed/${username}/${slug}?theme=dark&height=380" width="100%" height="380" style="border:0;border-radius:12px" title="Runit — ${(snippet as Snippet).name}"></iframe>`
+    : '';
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', background: '#f8f9fa' }}>
+      <AppHeader />
+
+      <Container size="lg" py="xl" style={{ width: '100%' }}>
+        {isLoading && (
+          <Center py={120}>
+            <Loader />
+          </Center>
+        )}
+
+        {!isLoading && (isError || !snippet) && <NotFoundState />}
+
+        {!isLoading && snippet && (
+          <Stack gap="xl">
+            <Stack gap="sm">
+              {/* Хлебная строка со ссылкой и статусом видимости */}
+              <Group gap="xs">
+                <Text c="dimmed" aria-hidden>
+                  🔗
+                </Text>
+                <Text ff="monospace" fz="sm" c="dimmed">
+                  {shareUrl}
+                </Text>
+                <Badge variant="light" color="green" size="sm" radius="sm" leftSection="•">
+                  публичный
+                </Badge>
+              </Group>
+
+              {/* Заголовок + действия. На мобильной ширине Group переносит блоки на новую строку. */}
+              <Group justify="space-between" align="flex-start" gap="md" wrap="wrap">
+                <Group gap="md" wrap="wrap">
+                  <Title order={2} ff="monospace">
+                    {(snippet as Snippet).name}
+                  </Title>
+                  <Badge
+                    variant="light"
+                    color="gray"
+                    size="lg"
+                    radius="sm"
+                    leftSection={
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 8,
+                          height: 8,
+                          borderRadius: '50%',
+                          background: meta?.dot ?? '#adb5bd',
+                        }}
+                      />
+                    }
+                  >
+                    {meta?.label ?? (snippet as Snippet).language}
+                  </Badge>
+                </Group>
+
+                <Group gap="sm" wrap="wrap">
+                  <Button
+                    variant="light"
+                    onClick={handleFork}
+                    loading={forkMutation.isPending}
+                    leftSection={<span aria-hidden>⑂</span>}
+                  >
+                    Форкнуть
+                  </Button>
+                  <CopyButton value={(snippet as Snippet).code}>
+                    {({ copied, copy }) => (
+                      <Button variant="default" onClick={copy}>
+                        {copied ? 'Скопировано' : 'Копировать код'}
+                      </Button>
+                    )}
+                  </CopyButton>
+                  <Button onClick={() => navigate(`/editor/${(snippet as Snippet).id}`)}>
+                    Открыть в редакторе
+                  </Button>
+                </Group>
+              </Group>
+
+              {/* Автор и метрики */}
+              <Group gap="xs">
+                <Avatar color="blue" radius="xl" size="sm">
+                  {initialsOf(username)}
+                </Avatar>
+                <Anchor component={Link} to={`/u/${username}`} fw={600} fz="sm" c="dark.9">
+                  {username}
+                </Anchor>
+                <Text fz="sm" c="dimmed">
+                  · {relativeDate((snippet as Snippet).updatedAt)}
+                </Text>
+                {/* TODO(#828, #840): реальные счётчики просмотров и форков с бэкенда. */}
+                <Tooltip label="В разработке (#828, #840)">
+                  <Text fz="sm" c="dimmed" style={{ cursor: 'help' }}>
+                    · — просмотров · — форков
+                  </Text>
+                </Tooltip>
+              </Group>
+            </Stack>
+
+            <CodeCard
+              snippet={snippet as Snippet}
+              onOpenEditor={() => navigate(`/editor/${(snippet as Snippet).id}`)}
+            />
+
+            {/* Встраивание */}
+            <Stack gap="xs">
+              <Title order={3}>Встроить этот сниппет</Title>
+              <Text c="dimmed" fz="sm">
+                Вставьте код на любую страницу — виджет всегда показывает актуальную версию.
+              </Text>
+              <Group align="stretch" gap="md" wrap="wrap">
+                <Box
+                  style={{
+                    flex: '1 1 320px',
+                    minWidth: 0,
+                    background: editorColors.bg,
+                    border: `1px solid ${editorColors.border}`,
+                    borderRadius: 12,
+                    padding: '14px 18px',
+                    overflowX: 'auto',
+                  }}
+                >
+                  <Text
+                    component="pre"
+                    ff="monospace"
+                    fz={13}
+                    c={editorColors.text}
+                    style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+                  >
+                    {embedCode}
+                  </Text>
+                </Box>
+                <CopyButton value={embedCode}>
+                  {({ copied, copy }) => (
+                    <Button variant="light" onClick={copy} style={{ alignSelf: 'flex-start' }}>
+                      {copied ? 'Скопировано' : 'Копировать код'}
+                    </Button>
+                  )}
+                </CopyButton>
+              </Group>
+            </Stack>
+
+            {/* Статистика — заглушка до появления аналитики на бэкенде */}
+            <Stack gap="xs">
+              <Title order={3}>Статистика</Title>
+              {/* TODO(#840): графики запусков и список страниц встраивания. */}
+              <Card withBorder radius="lg" padding="xl" style={{ opacity: 0.6 }}>
+                <Center py="lg">
+                  <Stack align="center" gap={4}>
+                    <Text fw={600} c="dimmed">
+                      Статистика появится позже (#840)
+                    </Text>
+                    <Text fz="sm" c="dimmed">
+                      Запуски за неделю и страницы встраивания — в разработке.
+                    </Text>
+                  </Stack>
+                </Center>
+              </Card>
+            </Stack>
+          </Stack>
+        )}
+      </Container>
+
+      <AppFooter />
+    </div>
+  );
+}

--- a/frontend/src/v2/runner.ts
+++ b/frontend/src/v2/runner.ts
@@ -1,0 +1,90 @@
+// MVP-раннер: исполняет JavaScript в Web Worker с перехватом console.* и stdin.
+// TODO(#821, #609): заменить на серверный сервис исполнения (все языки, докер).
+
+export type ConsoleLine = {
+  type: 'log' | 'error' | 'warn' | 'info' | 'system';
+  text: string;
+};
+
+export type RunResult = {
+  lines: ConsoleLine[];
+  exitCode: number;
+  durationMs: number;
+};
+
+const WORKER_SOURCE = `
+  const lines = [];
+  const push = (type, args) =>
+    lines.push({ type, text: args.map((a) => {
+      if (typeof a === 'string') return a;
+      try { return JSON.stringify(a); } catch { return String(a); }
+    }).join(' ') });
+  ['log', 'error', 'warn', 'info'].forEach((m) => {
+    console[m] = (...args) => push(m === 'info' ? 'info' : m, args);
+  });
+  self.onmessage = (e) => {
+    const { code, stdin } = e.data;
+    const stdinLines = (stdin || '').split('\\n');
+    let cursor = 0;
+    self.readline = () => (cursor < stdinLines.length ? stdinLines[cursor++] : null);
+    self.prompt = self.readline;
+    let exitCode = 0;
+    try {
+      new Function(code)();
+    } catch (err) {
+      exitCode = 1;
+      push('error', [err && err.stack ? String(err.message) : String(err)]);
+    }
+    self.postMessage({ lines, exitCode });
+  };
+`;
+
+export async function runJavaScript(
+  code: string,
+  stdin = '',
+  timeoutMs = 5000,
+): Promise<RunResult> {
+  const started = performance.now();
+  const blob = new Blob([WORKER_SOURCE], { type: 'application/javascript' });
+  const url = URL.createObjectURL(blob);
+  const worker = new Worker(url);
+
+  return new Promise<RunResult>((resolve) => {
+    const finish = (lines: ConsoleLine[], exitCode: number) => {
+      worker.terminate();
+      URL.revokeObjectURL(url);
+      resolve({ lines, exitCode, durationMs: performance.now() - started });
+    };
+    const timer = setTimeout(
+      () =>
+        finish(
+          [{ type: 'error', text: `Превышен лимит времени (${timeoutMs / 1000} c)` }],
+          1,
+        ),
+      timeoutMs,
+    );
+    worker.onmessage = (e) => {
+      clearTimeout(timer);
+      finish(e.data.lines, e.data.exitCode);
+    };
+    worker.onerror = (e) => {
+      clearTimeout(timer);
+      finish([{ type: 'error', text: e.message }], 1);
+    };
+    worker.postMessage({ code, stdin });
+  });
+}
+
+export function unsupportedLanguage(language: string): RunResult {
+  // TODO(#821, #616, #538): серверное исполнение остальных языков.
+  return {
+    lines: [
+      {
+        type: 'system',
+        text: `Среда исполнения для «${language}» появится позже — в MVP выполняется только JavaScript (#821).`,
+      },
+    ],
+    exitCode: 0,
+    durationMs: 0,
+  };
+}

--- a/frontend/src/v2/session.tsx
+++ b/frontend/src/v2/session.tsx
@@ -1,0 +1,99 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useTRPCClient } from '../utils/trpc';
+
+// TODO(#639, #792): мок-сессия до появления настоящей авторизации на бэкенде.
+// login не проверяет пароль (bcrypt-контур появится в #791/#639), сессия живёт
+// в localStorage. Контракт хука сохранится при переходе на реальный auth.
+
+export type SessionUser = {
+  id: number;
+  username: string;
+  email: string;
+};
+
+type SessionContextValue = {
+  user: SessionUser | null;
+  isGuest: boolean;
+  login: (email: string, password: string) => Promise<SessionUser>;
+  register: (username: string, email: string, password: string) => Promise<SessionUser>;
+  logout: () => void;
+};
+
+const STORAGE_KEY = 'runit.v2.session';
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+const readStored = (): SessionUser | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SessionUser) : null;
+  } catch {
+    return null;
+  }
+};
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const trpc = useTRPCClient();
+  const [user, setUser] = useState<SessionUser | null>(readStored);
+
+  const persist = useCallback((u: SessionUser | null) => {
+    if (u) localStorage.setItem(STORAGE_KEY, JSON.stringify(u));
+    else localStorage.removeItem(STORAGE_KEY);
+    setUser(u);
+  }, []);
+
+  const login = useCallback(
+    async (email: string, _password: string) => {
+      // TODO(#639): реальная проверка пароля на сервере.
+      const found = await trpc.users.getUserByEmail.query(email);
+      const u: SessionUser = {
+        id: found.id,
+        username: found.username,
+        email: found.email,
+      };
+      persist(u);
+      return u;
+    },
+    [trpc, persist],
+  );
+
+  const register = useCallback(
+    async (username: string, email: string, password: string) => {
+      const created = await trpc.users.createUser.mutate({
+        username,
+        email,
+        password,
+      });
+      const u: SessionUser = {
+        id: created.id,
+        username: created.username,
+        email: created.email,
+      };
+      persist(u);
+      return u;
+    },
+    [trpc, persist],
+  );
+
+  const logout = useCallback(() => persist(null), [persist]);
+
+  const value = useMemo(
+    () => ({ user, isGuest: !user, login, register, logout }),
+    [user, login, register, logout],
+  );
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('useSession must be used within SessionProvider');
+  return ctx;
+}

--- a/frontend/src/v2/theme.ts
+++ b/frontend/src/v2/theme.ts
@@ -1,0 +1,41 @@
+import { createTheme, rem } from '@mantine/core';
+
+// Дизайн-токены Runit v2 (см. docs/design/*.png):
+// светлый фон #f8f9fa, текст #212529, акцент — синий, код — JetBrains Mono.
+export const v2Theme = createTheme({
+  fontFamily: "'Golos Text', system-ui, -apple-system, sans-serif",
+  fontFamilyMonospace: "'JetBrains Mono', ui-monospace, monospace",
+  primaryColor: 'blue',
+  defaultRadius: 'md',
+  headings: {
+    fontFamily: "'Golos Text', system-ui, sans-serif",
+    fontWeight: '700',
+  },
+  components: {
+    Button: {
+      defaultProps: { radius: 'xl' },
+    },
+  },
+});
+
+// Цвета редактора (тёмная область кода на светлой странице)
+export const editorColors = {
+  bg: '#1a1b26',
+  panel: '#16161e',
+  border: '#2a2b3a',
+  text: '#c0caf5',
+  dim: '#565f89',
+  accent: '#4dabf7',
+  error: '#ff6b6b',
+  ok: '#51cf66',
+};
+
+export const langMeta: Record<string, { label: string; dot: string; runnable: boolean }> = {
+  javascript: { label: 'JavaScript', dot: '#f1e05a', runnable: true },
+  typescript: { label: 'TypeScript', dot: '#3178c6', runnable: false },
+  python: { label: 'Python', dot: '#3572A5', runnable: false },
+  php: { label: 'PHP', dot: '#4F5D95', runnable: false },
+  ruby: { label: 'Ruby', dot: '#701516', runnable: false },
+  java: { label: 'Java', dot: '#b07219', runnable: false },
+  html: { label: 'HTML', dot: '#e34c26', runnable: false },
+};


### PR DESCRIPTION
## Что это

MVP всего фронтенда по новому дизайну ([макеты](https://github.com/hexlet-volunteers/runit/tree/main/docs/design)). Новый интерфейс живёт в `frontend/src/v2/` и является приложением по умолчанию. **Mantine — единственная UI-библиотека** (bootstrap физически отключён от сборки). Легаси-страницы остались в репо (материал для #814/#815/#816), но не роутятся.

## Что работает end-to-end (проверено в браузере)

- Регистрация (реальный tRPC `users.createUser`) → мок-сессия
- Редактор: Monaco, запуск JS в Web Worker (консоль с цветным выводом, exit-код, stdin через вкладку ВВОД, Ctrl+Enter), автосохранение с индикатором, создание/загрузка сниппета через tRPC
- Кабинет: карточки, поиск/фильтр по языку/сортировка, модалка «Новый сниппет» (генератор имён, плитки языков), удаление
- Страница шаринга `/s/:username/:slug`: read-only код, запуск, **форк**, embed-код
- Embed-виджет `/embed/...` с `?theme=&height=`
- Лендинг с живым исполняемым демо; профиль; настройки (шрифт/консоль/таб — localStorage); правовая с табами; 404 в терминальном стиле; модалка входа/регистрации/сброса

## Что оставлено стажёрам (заглушки disabled+Tooltip + TODO(#N) в коде)

| Область | Задачи |
|---|---|
| Мультифайловость | #818, #819 |
| Серверное исполнение (все языки, docker) | #821, #609, #616 |
| Менеджер пакетов | #823, #824 |
| История версий | #836, #837 |
| Совместная сессия | #3, #318, #838, #839 |
| Статистика и счётчики | #828, #840 |
| Embed-варианты card/minimal/tabs | #841 |
| Bulk-операции и «Выбрать все» | #830, #613 |
| Серверные настройки/профиль | #832, #718, #717 |
| Реальная авторизация вместо мок-сессии | #639, #791, #792 |
| Сложность пароля / сброс | #621, #640, #620 |

## Найденный по пути баг бэкенда

`createdAt/updatedAt` приходят `null` (CURRENT_TIMESTAMP в integer-колонках) — заведено #847, во фронте временный фолбэк «недавно».

## Проверка

- `npm run build` (frontend) — зелёный
- Playwright-прогон: 7 маршрутов + e2e (регистрация → запуск кода → сохранение → кабинет → шаринг → embed → настройки) — 0 JS-ошибок