### PR TITLE
Fix/snippet name length

### DIFF
--- a/frontend/src/components/Modals/NewSnippet.tsx
+++ b/frontend/src/components/Modals/NewSnippet.tsx
@@ -21,7 +21,7 @@ import type {
 import routes from '../../routes';
 
 import { useAuth, useSnippets } from '../../hooks/index';
-import { snippetName } from '../../utils/validationSchemas';
+import { snippetName, SNIPPET_NAME_MAX_LENGTH } from '../../utils/validationSchemas';
 import { actions as modalActions } from '../../slices/modalSlice';
 import icons from '../../utils/icons';
 
@@ -294,6 +294,7 @@ function NewSnippet({ handleClose, isOpen }) {
                     disabled={!formik.values.template || isLoading}
                     id="name"
                     isInvalid={formik.errors.name && formik.touched.name}
+                    maxLength={SNIPPET_NAME_MAX_LENGTH}
                     name="name"
                     onChange={formik.handleChange}
                     value={formik.values.name}

--- a/src/db/snippets.ts
+++ b/src/db/snippets.ts
@@ -17,7 +17,7 @@ export const snippetSchema = z.object({
 });
  
 export const createSnippetSchema = z.object({
-  name: z.string().min(1).max(100),
+  name: z.string().min(1).max(30),
   code: z.string().min(1),
   slug: z.string().max(30).optional(),
   language: z.enum(['ruby', 'java', 'php', 'python', 'javascript', 'html']) ,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "declaration": true,
     "sourceMap": true
   },
-  "include": ["src/**/*", "types/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "types"]
 }

--- a/types/db/homePage.d.ts
+++ b/types/db/homePage.d.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod/v4';
+export declare const sectionSchema: z.ZodObject<{
+    id: z.ZodNumber;
+    title: z.ZodString;
+    description: z.ZodString;
+    content: z.ZodString;
+    componentType: z.ZodString;
+    createdAt: z.ZodOptional<z.ZodDate>;
+    updatedAt: z.ZodOptional<z.ZodDate>;
+}, z.core.$strip>;
+export declare const createSectionSchema: z.ZodObject<{
+    title: z.ZodString;
+    description: z.ZodString;
+    content: z.ZodString;
+    componentType: z.ZodString;
+}, z.core.$strip>;
+export declare const updateSectionSchema: z.ZodObject<{
+    title: z.ZodOptional<z.ZodString>;
+    description: z.ZodOptional<z.ZodString>;
+    content: z.ZodOptional<z.ZodString>;
+    componentType: z.ZodOptional<z.ZodString>;
+    id: z.ZodNumber;
+}, z.core.$strip>;
+export type ValidSection = z.infer<typeof sectionSchema>;
+export type CreateSectiontInput = z.infer<typeof createSectionSchema>;
+export type UpdateSectionInput = z.infer<typeof updateSectionSchema>;
+export declare function getHomePageData(): Promise<ValidSection[]>;
+export declare function getSectionById(id: number): Promise<ValidSection | undefined>;
+export declare function createSection(input: CreateSectiontInput): Promise<ValidSection>;
+export declare function updateSection(input: UpdateSectionInput): Promise<ValidSection>;

--- a/types/db/schema/schema.d.ts
+++ b/types/db/schema/schema.d.ts
@@ -432,6 +432,140 @@ export declare const snippets: import("drizzle-orm/sqlite-core").SQLiteTableWith
     };
     dialect: "sqlite";
 }>;
+export declare const sections: import("drizzle-orm/sqlite-core").SQLiteTableWithColumns<{
+    name: "sections";
+    schema: undefined;
+    columns: {
+        id: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "id";
+            tableName: "sections";
+            dataType: "number";
+            columnType: "SQLiteInteger";
+            data: number;
+            driverParam: number;
+            notNull: true;
+            hasDefault: true;
+            isPrimaryKey: true;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: undefined;
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {}>;
+        title: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "title";
+            tableName: "sections";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: true;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: number | undefined;
+        }>;
+        description: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "description";
+            tableName: "sections";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: true;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: number | undefined;
+        }>;
+        content: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "content";
+            tableName: "sections";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: true;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: number | undefined;
+        }>;
+        componentType: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "component_type";
+            tableName: "sections";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: true;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: number | undefined;
+        }>;
+        createdAt: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "created_at";
+            tableName: "sections";
+            dataType: "date";
+            columnType: "SQLiteTimestamp";
+            data: Date;
+            driverParam: number;
+            notNull: true;
+            hasDefault: true;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: undefined;
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {}>;
+        updatedAt: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "updated_at";
+            tableName: "sections";
+            dataType: "date";
+            columnType: "SQLiteTimestamp";
+            data: Date;
+            driverParam: number;
+            notNull: true;
+            hasDefault: true;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: undefined;
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {}>;
+    };
+    dialect: "sqlite";
+}>;
 export declare const usersRelations: import("drizzle-orm").Relations<"users", {
     snippets: import("drizzle-orm").Many<"snippets">;
     settings: import("drizzle-orm").One<"user_settings", true>;
@@ -448,3 +582,5 @@ export type Snippet = typeof snippets.$inferSelect;
 export type NewSnippet = typeof snippets.$inferInsert;
 export type UserSettings = typeof userSettings.$inferSelect;
 export type NewUserSettings = typeof userSettings.$inferInsert;
+export type Section = typeof sections.$inferSelect;
+export type NewSection = typeof sections.$inferInsert;

--- a/types/db/seedHomePageData.d.ts
+++ b/types/db/seedHomePageData.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Данные для главной страницы
+ * Запускается при инициализации для заполнения таблицы sections начальными данными, если она пустая
+ * Каждый компонент имеет title, description, content (в виде JSON строки) и componentType для определения типа компонента на фронте
+*/
+export declare function seedHomePageData(): Promise<void>;

--- a/types/router/homePageRouter.d.ts
+++ b/types/router/homePageRouter.d.ts
@@ -1,0 +1,72 @@
+export declare const homePageRouter: import("@trpc/server").TRPCBuiltRouter<{
+    ctx: object;
+    meta: object;
+    errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+    transformer: false;
+}, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+    getHomePageData: import("@trpc/server").TRPCQueryProcedure<{
+        input: void;
+        output: {
+            components: {
+                id: number;
+                title: string;
+                description: string;
+                content: string;
+                componentType: string;
+                createdAt?: Date | undefined;
+                updatedAt?: Date | undefined;
+            }[];
+        };
+        meta: object;
+    }>;
+    getComponentById: import("@trpc/server").TRPCQueryProcedure<{
+        input: number;
+        output: {
+            id: number;
+            title: string;
+            description: string;
+            content: string;
+            componentType: string;
+            createdAt?: Date | undefined;
+            updatedAt?: Date | undefined;
+        };
+        meta: object;
+    }>;
+    adminCreateComponent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            title: string;
+            description: string;
+            content: string;
+            componentType: string;
+        };
+        output: {
+            id: number;
+            title: string;
+            description: string;
+            content: string;
+            componentType: string;
+            createdAt?: Date | undefined;
+            updatedAt?: Date | undefined;
+        };
+        meta: object;
+    }>;
+    adminUpdateComponent: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            id: number;
+            title?: string | undefined;
+            description?: string | undefined;
+            content?: string | undefined;
+            componentType?: string | undefined;
+        };
+        output: {
+            id: number;
+            title: string;
+            description: string;
+            content: string;
+            componentType: string;
+            createdAt?: Date | undefined;
+            updatedAt?: Date | undefined;
+        };
+        meta: object;
+    }>;
+}>>;

--- a/types/router/index.d.ts
+++ b/types/router/index.d.ts
@@ -258,5 +258,77 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
             meta: object;
         }>;
     }>>;
+    homePage: import("@trpc/server").TRPCBuiltRouter<{
+        ctx: object;
+        meta: object;
+        errorShape: import("@trpc/server").TRPCDefaultErrorShape;
+        transformer: false;
+    }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
+        getHomePageData: import("@trpc/server").TRPCQueryProcedure<{
+            input: void;
+            output: {
+                components: {
+                    id: number;
+                    title: string;
+                    description: string;
+                    content: string;
+                    componentType: string;
+                    createdAt?: Date | undefined;
+                    updatedAt?: Date | undefined;
+                }[];
+            };
+            meta: object;
+        }>;
+        getComponentById: import("@trpc/server").TRPCQueryProcedure<{
+            input: number;
+            output: {
+                id: number;
+                title: string;
+                description: string;
+                content: string;
+                componentType: string;
+                createdAt?: Date | undefined;
+                updatedAt?: Date | undefined;
+            };
+            meta: object;
+        }>;
+        adminCreateComponent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                title: string;
+                description: string;
+                content: string;
+                componentType: string;
+            };
+            output: {
+                id: number;
+                title: string;
+                description: string;
+                content: string;
+                componentType: string;
+                createdAt?: Date | undefined;
+                updatedAt?: Date | undefined;
+            };
+            meta: object;
+        }>;
+        adminUpdateComponent: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                id: number;
+                title?: string | undefined;
+                description?: string | undefined;
+                content?: string | undefined;
+                componentType?: string | undefined;
+            };
+            output: {
+                id: number;
+                title: string;
+                description: string;
+                content: string;
+                componentType: string;
+                createdAt?: Date | undefined;
+                updatedAt?: Date | undefined;
+            };
+            meta: object;
+        }>;
+    }>>;
 }>>;
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
К задаче [#795 ](https://github.com/hexlet-volunteers/runit/issues/795)
**Бэкенд:**

createSnippetSchema — исправлен лимит имени сниппета с max(100) на max(30) (синхронизировано с DB и snippetSchema)
tsconfig.json — moduleResolution исправлен на bundler, добавлен rootDir, папка types/ перенесена в exclude

**Фронтенд:**

NewSnippet.tsx — добавлен maxLength={SNIPPET_NAME_MAX_LENGTH} на поле имени сниппета

**Инфраструктура:**

Перегенерированы TypeScript-декларации в types/