### PR TITLE
Fix/847 timestamp null

### DIFF
--- a/frontend/src/v2-legacy/pages/Dashboard/lib.ts
+++ b/frontend/src/v2-legacy/pages/Dashboard/lib.ts
@@ -23,7 +23,8 @@ export const plural = (n: number, forms: [string, string, string]): string => {
 };
 
 // Относительная дата по-русски: «2 часа назад», «вчера», «месяц назад».
-export function relativeDate(input: string | Date): string {
+export function relativeDate(input: string | Date | null | undefined): string {
+  if (!input) return '';
   const date = new Date(input);
   const diffMs = Date.now() - date.getTime();
   if (Number.isNaN(date.getTime())) return '';

--- a/frontend/src/v2-legacy/pages/Dashboard/lib.ts
+++ b/frontend/src/v2-legacy/pages/Dashboard/lib.ts
@@ -24,7 +24,6 @@ export const plural = (n: number, forms: [string, string, string]): string => {
 
 // Относительная дата по-русски: «2 часа назад», «вчера», «месяц назад».
 export function relativeDate(input: string | Date): string {
-  if (!input) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
   const date = new Date(input);
   const diffMs = Date.now() - date.getTime();
   if (Number.isNaN(date.getTime())) return '';

--- a/frontend/src/v2-legacy/pages/Share/index.tsx
+++ b/frontend/src/v2-legacy/pages/Share/index.tsx
@@ -51,7 +51,8 @@ export function fileNameOf(snippet: Pick<Snippet, 'name' | 'language'>): string 
 }
 
 // Относительная дата по-русски (упрощённо, без библиотек).
-export function relativeDate(iso: string): string {
+export function relativeDate(iso: string | null | undefined): string {
+  if (!iso) return '';
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '';
   const days = Math.floor((Date.now() - then) / (24 * 60 * 60 * 1000));

--- a/frontend/src/v2-legacy/pages/Share/index.tsx
+++ b/frontend/src/v2-legacy/pages/Share/index.tsx
@@ -52,9 +52,8 @@ export function fileNameOf(snippet: Pick<Snippet, 'name' | 'language'>): string 
 
 // Относительная дата по-русски (упрощённо, без библиотек).
 export function relativeDate(iso: string): string {
-  if (!iso) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
   const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return 'недавно';
+  if (Number.isNaN(then)) return '';
   const days = Math.floor((Date.now() - then) / (24 * 60 * 60 * 1000));
   if (days <= 0) return 'сегодня';
   if (days === 1) return 'вчера';

--- a/frontend/src/v2/pages/share/ui/SharePage.tsx
+++ b/frontend/src/v2/pages/share/ui/SharePage.tsx
@@ -33,10 +33,10 @@ import {
 } from '../../../entities/snippet';
 
 /** Относительная дата по-русски: «сегодня», «вчера», «N дн. назад» либо locale-дата. */
-export function relativeDate(iso: string): string {
-  if (!iso) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
+export function relativeDate(iso: string | null | undefined): string {
+  if (!iso) return '';
   const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return 'недавно';
+  if (Number.isNaN(then)) return '';
   const days = Math.floor((Date.now() - then) / (24 * 60 * 60 * 1000));
   if (days <= 0) return 'сегодня';
   if (days === 1) return 'вчера';

--- a/frontend/src/v2/shared/lib/dates.ts
+++ b/frontend/src/v2/shared/lib/dates.ts
@@ -8,8 +8,8 @@ export const plural = (n: number, forms: [string, string, string]): string => {
 };
 
 // Относительная дата по-русски: «2 часа назад», «вчера», «месяц назад».
-export function relativeDate(input: string | Date): string {
-  if (!input) return 'недавно'; // бэкенд может отдавать null в createdAt (баг таймстампов схемы)
+export function relativeDate(input: string | Date | null | undefined): string {
+  if (!input) return '';
   const date = new Date(input);
   const diffMs = Date.now() - date.getTime();
   if (Number.isNaN(date.getTime())) return '';

--- a/src/db/schema/schema.ts
+++ b/src/db/schema/schema.ts
@@ -9,8 +9,8 @@ export const users = sqliteTable('users', {
   password: text('password', { length: 60 }).notNull(),
   isAdmin: integer('is_admin', { mode: 'boolean' }).notNull().default(false),
   recoverHash: text('recover_hash', { length: 50 }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
 });
 
 export const userSettings = sqliteTable('user_settings', {
@@ -19,8 +19,8 @@ export const userSettings = sqliteTable('user_settings', {
   theme: text('theme', { length: 20 }).notNull().default('system'),
   language: text('language', { length: 10 }).notNull().default('ru'),
   avatarBase64: text('avatar_base64'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
 });
 
 export const snippets = sqliteTable('snippets', {
@@ -30,8 +30,8 @@ export const snippets = sqliteTable('snippets', {
   code: text('code').notNull(),
   language: text('language', { length: 50 }),
   userId: integer('user_id').references(() => users.id, { onDelete: 'cascade' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
 });
 
 export const sections = sqliteTable('sections', {
@@ -40,8 +40,8 @@ export const sections = sqliteTable('sections', {
   description: text('description').notNull(),
   content: text('content').notNull(),
   componentType: text('component_type').notNull(),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
 });
 
 export const usersRelations = relations(users, ({ many, one }) => ({


### PR DESCRIPTION
К задаче #847 

## Changes

- Replaced `CURRENT_TIMESTAMP` default with `(unixepoch())` in all timestamp columns (users, snippets, user_settings, sections) — SQLite now stores Unix integers that Drizzle correctly parses as Date objects
- Removed frontend fallbacks returning 'недавно' in Dashboard/lib.ts and Share/index.tsx that were masking null createdAt values


## Изменения

- Заменен дефолт `CURRENT_TIMESTAMP` на `(unixepoch())` во всех timestamp-колонках (users, snippets, user_settings, sections) — теперь SQLite записывает Unix-число, которое Drizzle корректно читает как Date
- Убраны фронтовые заглушки «недавно» в Dashboard/lib.ts и Share/index.tsx, которые скрывали null в createdAt
