### PR TITLE
feat(embedding): страница «Как это встраивается» по макету

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,28 @@
 # Образ бэкенда Runit (Fastify + tRPC + Drizzle).
 # Фронтенд собирается отдельно: frontend/Dockerfile (статика + Caddy).
+#
+# better-sqlite3 — нативный модуль, и для текущей версии готового бинарника под
+# Node 24 нет, поэтому он компилируется через node-gyp. Тулчейн (python3, make,
+# g++) нужен только на стадиях установки зависимостей: в финальный образ он не
+# попадает — туда копируются уже собранные node_modules.
+
+# ---------- Прод-зависимости (компилируются здесь) ----------
+FROM node:24-slim AS prod-deps
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
 
 # ---------- Сборка ----------
 FROM node:24-slim AS build
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -13,11 +33,11 @@ RUN npm ci
 
 COPY tsconfig.json drizzle.config.ts ./
 COPY src ./src
+COPY bin ./bin
 
 # Сборка: генерация миграций из схемы, компиляция и добавление расширений в
 # ESM-импорты (bin/fix-esm-imports.mjs — без него node dist/server.js падает).
 # Прогон миграций — при старте контейнера, в build-стадии боевой БД нет.
-COPY bin ./bin
 RUN npm run build
 
 # ---------- Рантайм ----------
@@ -26,10 +46,8 @@ FROM node:24-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
 
-# Только прод-зависимости: better-sqlite3 ставится из готового бинарника.
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
-
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/drizzle ./drizzle
 

--- a/frontend/src/v2/app/AppRouter.tsx
+++ b/frontend/src/v2/app/AppRouter.tsx
@@ -7,6 +7,7 @@ const Editor = lazy(() => import('../pages/editor/index'));
 const Dashboard = lazy(() => import('../pages/dashboard/index'));
 const Share = lazy(() => import('../pages/share/index'));
 const Embed = lazy(() => import('../pages/embed/index'));
+const Embedding = lazy(() => import('../pages/embedding/index'));
 const Profile = lazy(() => import('../pages/profile/index'));
 const Settings = lazy(() => import('../pages/settings/index'));
 const Legal = lazy(() => import('../pages/legal/index'));
@@ -30,6 +31,7 @@ export default function AppRouter() {
               <Route path="/snippets" element={<Dashboard />} />
               <Route path="/s/:username/:slug" element={<Share />} />
               <Route path="/embed/:username/:slug" element={<Embed />} />
+              <Route path="/embedding" element={<Embedding />} />
               <Route path="/u/:username" element={<Profile />} />
               <Route path="/settings" element={<Settings />} />
               <Route path="/legal" element={<Legal />} />

--- a/frontend/src/v2/pages/embedding/index.ts
+++ b/frontend/src/v2/pages/embedding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/EmbeddingPage';

--- a/frontend/src/v2/pages/embedding/lib/demoSnippet.ts
+++ b/frontend/src/v2/pages/embedding/lib/demoSnippet.ts
@@ -1,0 +1,22 @@
+// Пример из макета (docs/design/embed.png): урок про стрелочные функции.
+export const DEMO_FILE_NAME = 'greet.js';
+
+export const DEMO_CODE = [
+  '// Стрелочная функция: параметры ⇒ результат',
+  'const greet = (name) => `Привет, ${name}!`;',
+  '',
+  "const names = ['Хекслет', 'мир', 'Runit'];",
+  '',
+  'names.forEach((name) => {',
+  '  console.log(greet(name));',
+  '});',
+].join('\n');
+
+/** Варианты встраивания из макета: переключатель «вариант». */
+export const EMBED_VARIANTS = [
+  { value: 'card', label: 'Карточка' },
+  { value: 'minimal', label: 'Минимальный' },
+  { value: 'tabs', label: 'Вкладки' },
+] as const;
+
+export type EmbedVariant = (typeof EMBED_VARIANTS)[number]['value'];

--- a/frontend/src/v2/pages/embedding/ui/EmbeddedWidget.tsx
+++ b/frontend/src/v2/pages/embedding/ui/EmbeddedWidget.tsx
@@ -1,0 +1,254 @@
+import { useState } from 'react';
+import { Anchor, Box, Button, Group, Paper, Text } from '@mantine/core';
+import { CODE_FONT, highlightJs } from '../../../shared/lib';
+import { runCode, type RunResult } from '../../../shared/runner';
+import { editorColors, langMeta } from '../../../shared/theme';
+import { DEMO_CODE, DEMO_FILE_NAME, type EmbedVariant } from '../lib/demoSnippet';
+
+const lineColor = (type: string): string => {
+  if (type === 'error') return editorColors.error;
+  if (type === 'warn') return '#e5c07b';
+  if (type === 'system') return editorColors.dim;
+  return editorColors.text;
+};
+
+/** Иконка «молния» из футера виджета в макете. */
+const BoltIcon = () => (
+  <svg width={12} height={12} viewBox="0 0 24 24" fill="var(--mantine-color-blue-6)">
+    <path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z" />
+  </svg>
+);
+
+const PlayIcon = () => (
+  <svg width={10} height={10} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+);
+
+/** Редактируемый код с подсветкой: прозрачная textarea поверх <pre>. */
+function CodeArea({
+  code,
+  onChange,
+  minHeight = '9.5em',
+}: {
+  code: string;
+  onChange: (value: string) => void;
+  minHeight?: string;
+}) {
+  return (
+    <Box style={{ background: editorColors.bg, position: 'relative' }} p="sm">
+      <pre
+        aria-hidden
+        style={{ ...CODE_FONT, color: editorColors.text, minHeight }}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: `${highlightJs(code)}\n` }}
+      />
+      <textarea
+        value={code}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        aria-label={`Код ${DEMO_FILE_NAME}`}
+        spellCheck={false}
+        style={{
+          ...CODE_FONT,
+          position: 'absolute',
+          inset: 12,
+          width: 'calc(100% - 24px)',
+          height: 'calc(100% - 24px)',
+          background: 'transparent',
+          border: 'none',
+          outline: 'none',
+          resize: 'none',
+          color: 'transparent',
+          caretColor: editorColors.text,
+          overflow: 'hidden',
+        }}
+      />
+    </Box>
+  );
+}
+
+function ResultBlock({ result, compact = false }: { result: RunResult; compact?: boolean }) {
+  return (
+    <Box
+      px="md"
+      py={compact ? 8 : 'sm'}
+      style={{
+        background: editorColors.panel,
+        borderTop: `1px solid ${editorColors.border}`,
+      }}
+    >
+      <Group justify="space-between" mb={4}>
+        <Text
+          fz={11}
+          fw={700}
+          c={editorColors.dim}
+          style={{ letterSpacing: '0.08em', textTransform: 'uppercase' }}
+        >
+          Результат
+        </Text>
+        <Text fz={11} c={editorColors.dim}>
+          runit · {Math.max(1, Math.round(result.durationMs))} мс
+        </Text>
+      </Group>
+      {result.lines.length === 0 ? (
+        <Text ff="monospace" fz={13} c={editorColors.dim}>
+          (нет вывода)
+        </Text>
+      ) : (
+        result.lines.map((line, index) => (
+          <Text
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            ff="monospace"
+            fz={13}
+            style={{
+              color: lineColor(line.type),
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {line.text}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Виджет Runit, встроенный в чужую страницу — три варианта из макета
+ * (docs/design/embed.png): «Карточка», «Минимальный», «Вкладки».
+ *
+ * Код исполняется по-настоящему: JavaScript выполняется в Web Worker, поэтому
+ * демо работает без сервера. TODO(#841): собрать это в отдельный embed-бандл,
+ * который подключается на сторонние сайты.
+ */
+export default function EmbeddedWidget({ variant }: { variant: EmbedVariant }) {
+  const [code, setCode] = useState(DEMO_CODE);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const [tab, setTab] = useState<'code' | 'result'>('code');
+
+  const meta = langMeta.javascript;
+
+  const handleRun = async () => {
+    setRunning(true);
+    try {
+      const next = await runCode({ language: 'javascript', code });
+      setResult(next);
+      setTab('result');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const runButton = (size: 'xs' | 'sm' = 'xs') => (
+    <Button size={size} radius="md" loading={running} onClick={handleRun} leftSection={<PlayIcon />}>
+      Запустить
+    </Button>
+  );
+
+  const openInRunit = (
+    <Anchor href="/editor" target="_blank" fz="sm" fw={600}>
+      Открыть в Runit ↗
+    </Anchor>
+  );
+
+  // --- Минимальный: только код и запуск, без шапки и футера ---------------
+  if (variant === 'minimal') {
+    return (
+      <Paper radius="md" withBorder style={{ overflow: 'hidden' }}>
+        <Box style={{ position: 'relative' }}>
+          <CodeArea code={code} onChange={setCode} minHeight="9.5em" />
+          <Box style={{ position: 'absolute', top: 8, right: 8 }}>{runButton()}</Box>
+        </Box>
+        {result && <ResultBlock result={result} compact />}
+      </Paper>
+    );
+  }
+
+  // --- Вкладки: «Код» / «Результат» ---------------------------------------
+  if (variant === 'tabs') {
+    return (
+      <Paper radius="md" withBorder style={{ overflow: 'hidden' }}>
+        <Group
+          justify="space-between"
+          px="md"
+          py={8}
+          style={{ background: '#fff', borderBottom: '1px solid #e9ecef' }}
+        >
+          <Group gap={4}>
+            {(
+              [
+                ['code', 'Код'],
+                ['result', 'Результат'],
+              ] as const
+            ).map(([value, label]) => (
+              <Button
+                key={value}
+                size="compact-sm"
+                variant={tab === value ? 'light' : 'subtle'}
+                color={tab === value ? 'blue' : 'gray'}
+                radius="md"
+                onClick={() => setTab(value)}
+              >
+                {label}
+              </Button>
+            ))}
+          </Group>
+          {runButton()}
+        </Group>
+
+        {tab === 'code' ? (
+          <CodeArea code={code} onChange={setCode} minHeight="9.5em" />
+        ) : result ? (
+          <ResultBlock result={result} />
+        ) : (
+          <Box px="md" py="lg" style={{ background: editorColors.panel }}>
+            <Text ff="monospace" fz={13} c={editorColors.dim}>
+              Запустите код, чтобы увидеть результат
+            </Text>
+          </Box>
+        )}
+      </Paper>
+    );
+  }
+
+  // --- Карточка (по умолчанию) --------------------------------------------
+  return (
+    <Paper radius="md" withBorder style={{ overflow: 'hidden' }}>
+      <Group
+        justify="space-between"
+        px="md"
+        py={10}
+        style={{ background: '#fff', borderBottom: '1px solid #e9ecef' }}
+        wrap="nowrap"
+      >
+        <Group gap={8} wrap="nowrap">
+          <Text ff="monospace" fz="sm" fw={600} c="dark.9">
+            {DEMO_FILE_NAME}
+          </Text>
+          <Box w={8} h={8} style={{ borderRadius: '50%', background: meta.dot }} />
+          <Text fz="sm" c="dimmed">
+            {meta.label}
+          </Text>
+        </Group>
+        <Group gap="md" wrap="nowrap">
+          {openInRunit}
+          {runButton()}
+        </Group>
+      </Group>
+
+      <CodeArea code={code} onChange={setCode} />
+
+      {result && <ResultBlock result={result} />}
+
+      <Group gap={6} px="md" py={8} style={{ background: '#fff', borderTop: '1px solid #e9ecef' }}>
+        <BoltIcon />
+        <Text fz="xs" c="dimmed">
+          Работает на Runit
+        </Text>
+      </Group>
+    </Paper>
+  );
+}

--- a/frontend/src/v2/pages/embedding/ui/EmbeddingPage.tsx
+++ b/frontend/src/v2/pages/embedding/ui/EmbeddingPage.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Anchor,
+  Avatar,
+  Box,
+  Button,
+  Code,
+  Container,
+  Group,
+  Paper,
+  Text,
+  Title,
+} from '@mantine/core';
+import { EMBED_VARIANTS, type EmbedVariant } from '../lib/demoSnippet';
+import EmbeddedWidget from './EmbeddedWidget';
+
+// Страница-демонстрация: как виджет Runit выглядит внутри страницы урока
+// Хекслета (docs/design/embed.png). Открывается с лендинга по кнопке
+// «Как это встраивается →».
+
+/** Верхняя панель демо: возврат в Runit и переключатель варианта виджета. */
+function DemoBar({
+  variant,
+  onVariantChange,
+}: {
+  variant: EmbedVariant;
+  onVariantChange: (value: EmbedVariant) => void;
+}) {
+  return (
+    <Container size="lg" py="md">
+      <Group
+        maw={1000}
+        mx="auto"
+        justify="center"
+        gap="lg"
+        px="md"
+        py={10}
+        wrap="wrap"
+        style={{
+          border: '1px dashed #ced4da',
+          borderRadius: 12,
+          background: 'rgba(255, 255, 255, 0.6)',
+        }}
+      >
+        <Button component={Link} to="/" variant="default" radius="md" size="sm">
+          ← Вернуться в Runit
+        </Button>
+
+        <Text c="dimmed" fz="sm">
+          Демо: виджет Runit в уроке Хекслета · вариант
+        </Text>
+
+        <Group gap={4}>
+          {EMBED_VARIANTS.map((item) => (
+            <Button
+              key={item.value}
+              size="compact-sm"
+              radius="md"
+              variant={variant === item.value ? 'white' : 'subtle'}
+              color={variant === item.value ? 'dark' : 'gray'}
+              fw={variant === item.value ? 700 : 500}
+              onClick={() => onVariantChange(item.value)}
+              style={
+                variant === item.value
+                  ? { border: '1px solid #dee2e6', boxShadow: '0 1px 2px rgba(0,0,0,.06)' }
+                  : undefined
+              }
+            >
+              {item.label}
+            </Button>
+          ))}
+        </Group>
+      </Group>
+    </Container>
+  );
+}
+
+/** Шапка «чужого» сайта — имитация Хекслета, чтобы виджет был в контексте. */
+function HexletHeader() {
+  return (
+    <Group
+      justify="space-between"
+      px={{ base: 'md', sm: 40 }}
+      py="md"
+      style={{ background: '#1a1b26' }}
+      wrap="nowrap"
+    >
+      <Group gap={28} wrap="nowrap">
+        <Text fw={800} fz="lg" c="#fff">
+          Хекслет
+        </Text>
+        {['Курсы', 'Программы', 'Сообщество'].map((item) => (
+          <Text key={item} fz="sm" c="rgba(255,255,255,.75)" visibleFrom="sm">
+            {item}
+          </Text>
+        ))}
+      </Group>
+      <Avatar radius="xl" size={34} color="orange" variant="filled">
+        ВЛ
+      </Avatar>
+    </Group>
+  );
+}
+
+export default function EmbeddingPage() {
+  const [variant, setVariant] = useState<EmbedVariant>('card');
+
+  return (
+    <div style={{ minHeight: '100vh', background: '#eef0f4' }}>
+      <DemoBar variant={variant} onVariantChange={setVariant} />
+
+      <Container size="lg" pb={64}>
+        {/* Имитация страницы урока на сайте Хекслета */}
+        <Paper radius="lg" shadow="md" style={{ overflow: 'hidden' }}>
+          <HexletHeader />
+
+          <Box px={{ base: 'md', sm: 40 }} py={{ base: 'lg', sm: 40 }} bg="#fff">
+            <Box maw={720}>
+              <Text fw={600} c="blue.6" mb="xs">
+                JavaScript: Функции · Урок 7 из 12
+              </Text>
+
+              <Title order={1} fz={{ base: 30, sm: 38 }} mb="lg">
+                Стрелочные функции
+              </Title>
+
+              <Text mb="lg" fz="md" lh={1.7} c="dark.6">
+                В прошлом уроке мы объявляли функции через ключевое слово <Code>function</Code>.
+                В современном JavaScript чаще используют стрелочные функции — компактный
+                синтаксис, который особенно удобен для колбэков.
+              </Text>
+
+              <Title order={2} fz="xl" mt="xl" mb="sm">
+                Синтаксис
+              </Title>
+
+              <Text mb="lg" fz="md" lh={1.7} c="dark.6">
+                Стрелочная функция — это список параметров, стрелка <Code>⇒</Code> и тело.
+                Если тело состоит из одного выражения, его результат возвращается
+                автоматически, без <Code>return</Code>:
+              </Text>
+
+              {/* Собственно встроенный виджет Runit */}
+              <Box my="xl">
+                <EmbeddedWidget variant={variant} />
+              </Box>
+
+              <Text mb="lg" fz="md" lh={1.7} c="dark.6">
+                <Code>greet</Code> — обычная константа, в которой лежит функция. Её можно
+                передавать в другие функции, возвращать и хранить в структурах данных.
+              </Text>
+
+              <Group
+                gap="sm"
+                align="flex-start"
+                wrap="nowrap"
+                p="md"
+                mt="xl"
+                style={{ background: 'var(--mantine-color-blue-0)', borderRadius: 12 }}
+              >
+                <Text c="blue.6" fz="lg" lh={1}>
+                  ⓘ
+                </Text>
+                <Text fz="sm" lh={1.6} c="dark.6">
+                  Код в примере живой: замените имя в массиве <Code>names</Code> и нажмите
+                  «Запустить» — он выполнится по-настоящему.
+                </Text>
+              </Group>
+
+              {/* Навигация по урокам «чужого» сайта */}
+              <Group justify="space-between" mt={40} wrap="wrap" gap="sm">
+                <Button variant="default" radius="md">
+                  ← Функции как данные
+                </Button>
+                <Button radius="md">Далее: Замыкания →</Button>
+              </Group>
+            </Box>
+          </Box>
+        </Paper>
+
+        {/* Пояснение уже от лица Runit — зачем это нужно автору курса */}
+        <Group justify="center" mt="xl">
+          <Text ta="center" c="dimmed" fz="sm" maw={640}>
+            Так выглядит сниппет Runit, встроенный в страницу урока: читатель меняет код и
+            запускает его, не покидая сайт. Код для вставки берётся в редакторе — кнопка
+            «Поделиться» → «Встроить на сайт».{' '}
+            <Anchor component={Link} to="/editor">
+              Попробовать в редакторе
+            </Anchor>
+          </Text>
+        </Group>
+      </Container>
+    </div>
+  );
+}

--- a/frontend/src/v2/pages/landing/ui/DemoWidget.tsx
+++ b/frontend/src/v2/pages/landing/ui/DemoWidget.tsx
@@ -2,46 +2,7 @@ import { useState } from 'react';
 import { Box, Button, Group, Paper, Text } from '@mantine/core';
 import { editorColors, langMeta } from '../../../shared/theme';
 import { runCode, type RunResult } from '../../../shared/runner';
-
-/** Палитра подсветки синтаксиса (tokyo-night). */
-const HL = {
-  comment: '#565f89',
-  keyword: '#bb9af7',
-  string: '#9ece6a',
-  number: '#ff9e64',
-  method: '#4dabf7',
-};
-
-/** Экранирует HTML-спецсимволы для безопасной вставки в разметку. */
-const escapeHtml = (s: string) =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-/** Лёгкая regex-подсветка JavaScript для демо-виджета. */
-function highlightJS(src: string): string {
-const re =
-  /(\/\/[^\n]*)|('(?:[^'\\\n]|\\.)*'|"(?:[^"\\\n]|\\.)*"|`(?:[^`\\]|\\.)*`)|\b(const|let|var|function|return|if|else|for|while|of|in|new|class|true|false|null|undefined)\b|\b(\d+(?:\.\d+)?)\b|\b(forEach|log|map|filter|reduce|push|pop|shift|unshift)\b/g;
-  let out = '';
-  let last = 0;
-  for (let m = re.exec(src); m; m = re.exec(src)) {
-    out += escapeHtml(src.slice(last, m.index));
-    const [full, comment, str, kw, num, method] = m;
-    const color = comment ? HL.comment : str ? HL.string : kw ? HL.keyword : num ? HL.number : method ? HL.method : HL.number;
-    out += `<span style="color:${color}">${escapeHtml(full)}</span>`;
-    last = m.index + full.length;
-  }
-  return out + escapeHtml(src.slice(last));
-}
-
-/** Стили для моноширинного отображения кода. */
-const CODE_FONT: React.CSSProperties = {
-  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
-  fontSize: 14,
-  lineHeight: 1.7,
-  padding: '4px 8px',
-  margin: 0,
-  whiteSpace: 'pre-wrap',
-  wordBreak: 'break-word',
-};
+import { CODE_FONT, highlightJs } from '../../../shared/lib';
 
 /** Начальный код для демо-виджета. */
 const INITIAL_CODE = `// Попробуйте — код выполняется по-настоящему
@@ -137,7 +98,7 @@ export default function DemoWidget() {
           <pre
             style={{ ...CODE_FONT, color: editorColors.text, minHeight: '11em' }}
             // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: `${highlightJS(code)}\n` }}
+            dangerouslySetInnerHTML={{ __html: `${highlightJs(code)}\n` }}
           />
         </Box>
 

--- a/frontend/src/v2/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/v2/pages/landing/ui/LandingPage.tsx
@@ -88,8 +88,7 @@ export default function LandingPage() {
               <Button size="lg" component={Link} to="/editor">
                 Создать сниппет
               </Button>
-              {/* TODO(#841): позже ведёт на демо-страницу встраивания; пока — к секции фич */}
-              <Button size="lg" variant="light" onClick={scrollToEmbedding}>
+              <Button size="lg" variant="light" component={Link} to="/embedding">
                 Как это встраивается →
               </Button>
             </Group>

--- a/frontend/src/v2/shared/lib/highlightJs.ts
+++ b/frontend/src/v2/shared/lib/highlightJs.ts
@@ -1,0 +1,60 @@
+import type { CSSProperties } from 'react';
+
+// Лёгкая подсветка JavaScript для демо-виджетов (лендинг, страница встраивания).
+// В полноценном редакторе подсветку делает Monaco — здесь она не нужна и слишком
+// тяжела, поэтому обходимся регулярным выражением.
+
+/** Палитра подсветки (tokyo-night, как в макетах). */
+const HL = {
+  comment: '#565f89',
+  keyword: '#bb9af7',
+  string: '#9ece6a',
+  number: '#ff9e64',
+  method: '#4dabf7',
+};
+
+/** Экранирует HTML-спецсимволы: подсветка вставляется через innerHTML. */
+const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const TOKENS =
+  /(\/\/[^\n]*)|('(?:[^'\\\n]|\\.)*'|"(?:[^"\\\n]|\\.)*"|`(?:[^`\\]|\\.)*`)|\b(const|let|var|function|return|if|else|for|while|of|in|new|class|true|false|null|undefined)\b|\b(\d+(?:\.\d+)?)\b|\b(forEach|log|map|filter|reduce|push|pop|shift|unshift)\b/g;
+
+/**
+ * Возвращает HTML с раскрашенными токенами.
+ * Весь пользовательский текст экранируется, поэтому результат безопасен
+ * для вставки через dangerouslySetInnerHTML.
+ */
+export function highlightJs(src: string): string {
+  let out = '';
+  let last = 0;
+  for (let match = TOKENS.exec(src); match; match = TOKENS.exec(src)) {
+    out += escapeHtml(src.slice(last, match.index));
+    const [full, comment, str, keyword, num, method] = match;
+    const color = comment
+      ? HL.comment
+      : str
+        ? HL.string
+        : keyword
+          ? HL.keyword
+          : num
+            ? HL.number
+            : method
+              ? HL.method
+              : HL.number;
+    out += `<span style="color:${color}">${escapeHtml(full)}</span>`;
+    last = match.index + full.length;
+  }
+  return out + escapeHtml(src.slice(last));
+}
+
+/** Моноширинные стили для блоков кода в демо-виджетах. */
+export const CODE_FONT: CSSProperties = {
+  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+  fontSize: 14,
+  lineHeight: 1.7,
+  padding: '4px 8px',
+  margin: 0,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+};

--- a/frontend/src/v2/shared/lib/index.ts
+++ b/frontend/src/v2/shared/lib/index.ts
@@ -1,3 +1,4 @@
 export { plural, relativeDate } from './dates';
 export { initialsOf } from './initialsOf';
 export { copyToClipboard } from './clipboard';
+export { highlightJs, CODE_FONT } from './highlightJs';

--- a/frontend/src/v2/widgets/footer/AppFooter.tsx
+++ b/frontend/src/v2/widgets/footer/AppFooter.tsx
@@ -19,7 +19,7 @@ export default function AppFooter() {
             <Anchor component={Link} to="/#features" c="dimmed" fz="sm">
               Возможности
             </Anchor>
-            <Anchor component={Link} to="/#embedding" c="dimmed" fz="sm">
+            <Anchor component={Link} to="/embedding" c="dimmed" fz="sm">
               Встраивание
             </Anchor>
             <Anchor component={Link} to="/legal" c="dimmed" fz="sm">

--- a/frontend/src/v2/widgets/header/AppHeader.tsx
+++ b/frontend/src/v2/widgets/header/AppHeader.tsx
@@ -29,7 +29,7 @@ export default function AppHeader() {
           </UnstyledButton>
 
           <Group gap="sm">
-            <Button variant="subtle" color="gray" component={Link} to="/#embedding">
+            <Button variant="subtle" color="gray" component={Link} to="/embedding">
               Встраивание
             </Button>
             {isGuest ? (


### PR DESCRIPTION
Part of #841

## Проблема

Кнопка «Как это встраивается →» на лендинге вела в никуда — скроллила к секции фич, потому что самой страницы не существовало. При этом в дизайне для неё есть отдельный экран: [`docs/design/embed.png`](https://github.com/hexlet-volunteers/runit/blob/main/docs/design/embed.png).

## Что сделано

Страница `/embedding` собрана по макету:

* **демо-панель** сверху (пунктирная рамка): «← Вернуться в Runit», подпись «Демо: виджет Runit в уроке Хекслета · вариант» и переключатель **Карточка / Минимальный / Вкладки**;
* **имитация страницы урока Хекслета**: тёмная шапка с навигацией и оранжевым аватаром, крошка «JavaScript: Функции · Урок 7 из 12», заголовок «Стрелочные функции», текст с инлайн-кодом, голубой инфо-блок, навигация «← Функции как данные» / «Далее: Замыкания →». Это важно по смыслу: виджет должен быть виден **в чужом контексте**, иначе демонстрация ничего не показывает;
* **встроенный виджет Runit с живым кодом** — JavaScript исполняется в Web Worker, поэтому демо работает без сервера и без БД. Код редактируемый: текст урока прямо предлагает «замените имя в массиве `names` и нажмите „Запустить“».

Три варианта виджета из макета:

| Вариант | Что показывает |
| --- | --- |
| Карточка | шапка `greet.js` + язык, «Открыть в Runit ↗», кнопка запуска, футер «⚡ Работает на Runit» |
| Минимальный | только код и кнопка запуска, компактный блок результата |
| Вкладки | переключение «Код» / «Результат», в пустом состоянии — «Запустите код, чтобы увидеть результат» |

Ссылки «Встраивание» в шапке и футере теперь ведут на эту страницу, а не на анкор лендинга.

## Попутный рефакторинг

Подсветка синтаксиса жила внутри `DemoWidget` — вынес в `shared/lib/highlightJs.ts` и переиспользую в обоих виджетах вместо копии. Экранирование HTML сохранено (подсветка вставляется через `innerHTML`).

## Проверка

Playwright по живой странице: переход с лендинга ведёт на `/embedding`; присутствуют все блоки макета (демо-панель, шапка Хекслета, крошка, заголовки, виджет, футер «Работает на Runit», инфо-блок, навигация урока); **код реально исполняется** — после «Запустить» в результате появляется «Привет, Хекслет!»; все три варианта отрисовываются; 0 ошибок в консоли. `npm run build` — зелёный.

Скриншоты вариантов «Карточка» и «Вкладки» сверил с макетом — совпадают по составу и порядку блоков.