### PR TITLE
feat(share): приватность, короткие ссылки и встраивание по ссылке (oEmbed)

### DIFF
--- a/frontend/Caddyfile.docker
+++ b/frontend/Caddyfile.docker
@@ -18,6 +18,19 @@
 		reverse_proxy app:3001
 	}
 
+	# Встраивание по ссылке: сам oEmbed-эндпоинт и HTML с метатегами.
+	handle /oembed* {
+		reverse_proxy app:3001
+	}
+
+	# Боты (превью в мессенджерах, oEmbed-discovery площадок) должны получать
+	# HTML с Open Graph, а не SPA-оболочку без метатегов. Людям отдаём приложение.
+	@bots header_regexp User-Agent (?i)(bot|crawler|spider|facebookexternalhit|twitterbot|slackbot|telegrambot|discordbot|whatsapp|vkshare|embedly|quora link preview|redditbot|linkedinbot)
+	handle @bots {
+		rewrite /s/* /s/{http.request.uri.path.1}/meta
+		reverse_proxy app:3001
+	}
+
 	# SPA: любой неизвестный путь отдаёт index.html,
 	# иначе прямой заход на /editor/123 вернул бы 404.
 	handle {

--- a/frontend/src/v2/app/AppRouter.tsx
+++ b/frontend/src/v2/app/AppRouter.tsx
@@ -29,7 +29,10 @@ export default function AppRouter() {
               <Route path="/editor" element={<Editor />} />
               <Route path="/editor/:id" element={<Editor />} />
               <Route path="/snippets" element={<Dashboard />} />
+              {/* Короткая ссылка — основная; путь с username/slug сохранён для старых ссылок. */}
+              <Route path="/s/:shortCode" element={<Share />} />
               <Route path="/s/:username/:slug" element={<Share />} />
+              <Route path="/embed/s/:shortCode" element={<Embed />} />
               <Route path="/embed/:username/:slug" element={<Embed />} />
               <Route path="/embedding" element={<Embedding />} />
               <Route path="/u/:username" element={<Profile />} />

--- a/frontend/src/v2/entities/snippet/api/index.ts
+++ b/frontend/src/v2/entities/snippet/api/index.ts
@@ -2,5 +2,6 @@ export { createSnippet } from './createSnippet';
 export { updateSnippet } from './updateSnippet';
 export { useSnippetById } from './useSnippetById';
 export { useSnippetBySlug } from './useSnippetBySlug';
+export { useSnippetByShortCode } from './useSnippetByShortCode';
 export { generateSnippetName } from './generateSnippetName';
 export { getAllSnippets } from './getAllSnippets';

--- a/frontend/src/v2/entities/snippet/api/useSnippetByShortCode.ts
+++ b/frontend/src/v2/entities/snippet/api/useSnippetByShortCode.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTRPCClient } from '../../../shared/api';
+
+/**
+ * Сниппет по короткой ссылке (/s/aB3xK9).
+ * Приватные сниппеты сервер по коду не отдаёт — запрос вернёт ошибку.
+ */
+export function useSnippetByShortCode(shortCode: string | undefined) {
+  const trpc = useTRPCClient();
+  return useQuery({
+    queryKey: ['snippet-by-short-code', shortCode],
+    queryFn: () => trpc.snippets.getSnippetByShortCode.query(shortCode as string),
+    enabled: Boolean(shortCode),
+    retry: false,
+  });
+}

--- a/frontend/src/v2/entities/snippet/api/useSnippetBySlug.ts
+++ b/frontend/src/v2/entities/snippet/api/useSnippetBySlug.ts
@@ -9,6 +9,8 @@ export function useSnippetBySlug(username: string, slug: string) {
     queryKey: ['v2', 'snippet-by-slug', username, slug],
     queryFn: () =>
       trpc.snippets.getSnippetByUsernameSlug.query({ username, slug }),
+    // Не стреляем пустыми параметрами: при короткой ссылке данные берёт другой хук.
+    enabled: Boolean(username && slug),
     retry: false,
   });
 }

--- a/frontend/src/v2/entities/snippet/index.ts
+++ b/frontend/src/v2/entities/snippet/index.ts
@@ -4,6 +4,7 @@ export { SNIPPETS_QUERY_KEY } from './lib/constants';
 export {
   useSnippetById,
   useSnippetBySlug,
+  useSnippetByShortCode,
   generateSnippetName,
   createSnippet,
   updateSnippet,

--- a/frontend/src/v2/features/share-snippet/types.ts
+++ b/frontend/src/v2/features/share-snippet/types.ts
@@ -5,4 +5,10 @@ export type Props = {
   username: string;
   slug: string;
   saved: boolean;
+  /** id сниппета — нужен для смены уровня доступа. */
+  snippetId?: number | null;
+  /** Короткий код публичной ссылки (/s/aB3xK9). */
+  shortCode?: string | null;
+  /** Текущий уровень доступа: private | link | public. */
+  visibility?: string | null;
 };

--- a/frontend/src/v2/features/share-snippet/ui/ShareModal.tsx
+++ b/frontend/src/v2/features/share-snippet/ui/ShareModal.tsx
@@ -14,18 +14,59 @@ import {
   Text,
   TextInput,
 } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { copyToClipboard } from '../../../shared/lib';
+import { useTRPCClient } from '../../../shared/api';
 import { type Props } from '..'
 
 /** Модальное окно со ссылкой на сниппет и кодом для встраивания на сайт. */
-export default function ShareModal({ opened, onClose, username, slug, saved }: Props) {
+export default function ShareModal({
+  opened,
+  onClose,
+  username,
+  slug,
+  saved,
+  snippetId,
+  shortCode,
+  visibility,
+}: Props) {
+  const trpc = useTRPCClient();
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
   const [height, setHeight] = useState('380');
+  // Оптимистичное состояние тумблера: сервер подтверждает мутацией.
+  const [shared, setShared] = useState((visibility ?? 'private') !== 'private');
+  const [saving, setSaving] = useState(false);
 
   const origin = window.location.origin;
-  const pagePath = `/s/${username}/${slug}`;
+  // Короткая ссылка — основная: её удобно диктовать, и по ней работает
+  // встраивание по ссылке (oEmbed). Путь с username/slug остаётся рабочим.
+  const pagePath = shortCode ? `/s/${shortCode}` : `/s/${username}/${slug}`;
   const shareUrl = `${origin}${pagePath}`;
-  const embedCode = `<iframe src="${origin}/embed/${username}/${slug}?theme=${theme}&height=${height}" width="100%" height="${height}" style="border:0;border-radius:12px" title="Runit"></iframe>`;
+  const embedSrc = shortCode
+    ? `${origin}/embed/s/${shortCode}?theme=${theme}&height=${height}`
+    : `${origin}/embed/${username}/${slug}?theme=${theme}&height=${height}`;
+  const embedCode = `<iframe src="${embedSrc}" width="100%" height="${height}" style="border:0;border-radius:12px" title="Runit"></iframe>`;
+
+  /** Публикация и снятие публикации. */
+  const toggleShared = async (next: boolean) => {
+    if (snippetId == null) return;
+    setShared(next);
+    setSaving(true);
+    try {
+      await trpc.snippets.setVisibility.mutate({
+        id: snippetId,
+        visibility: next ? 'link' : 'private',
+      });
+      notifications.show({
+        message: next ? 'Сниппет доступен по ссылке' : 'Сниппет снова приватный',
+      });
+    } catch {
+      setShared(!next);
+      notifications.show({ message: 'Не удалось изменить доступ', color: 'red' });
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <Modal
@@ -41,11 +82,17 @@ export default function ShareModal({ opened, onClose, username, slug, saved }: P
           <div>
             <Text fw={600}>Доступ по ссылке</Text>
             <Text fz="sm" c="dimmed">
-              Просматривать могут все, у кого есть ссылка
+              {shared
+                ? 'Просматривать могут все, у кого есть ссылка'
+                : 'Сниппет приватный — ссылка и встраивание не работают'}
             </Text>
           </div>
-          {/* TODO(#643, #828): реальное управление приватностью — тумблер пока визуальный */}
-          <Switch defaultChecked size="md" />
+          <Switch
+            size="md"
+            checked={shared}
+            disabled={saving || snippetId == null}
+            onChange={(event) => toggleShared(event.currentTarget.checked)}
+          />
         </Group>
 
         <div>
@@ -108,6 +155,30 @@ export default function ShareModal({ opened, onClose, username, slug, saved }: P
               onClick={() => copyToClipboard(embedCode, 'Код для вставки скопирован')}
             >
               Копировать код
+            </Button>
+          </Group>
+        </div>
+
+        <Divider />
+
+        {/* Встраивание по ссылке (oEmbed) — как у YouTube: площадка сама
+            разворачивает ссылку в виджет, iframe писать не нужно. */}
+        <div>
+          <Text fz={11} fw={700} c="dimmed" mb={6} style={{ letterSpacing: '0.08em' }}>
+            ИЛИ ПРОСТО ВСТАВЬТЕ ССЫЛКУ
+          </Text>
+          <Text fz="sm" c="dimmed" mb="xs">
+            В WordPress, Notion, Discourse и мессенджерах достаточно вставить ссылку на
+            сниппет — виджет появится сам, без кода. Ссылка та же, что выше.
+          </Text>
+          <Group gap="sm" wrap="nowrap">
+            <TextInput value={shareUrl} readOnly style={{ flex: 1 }} ff="monospace" />
+            <Button
+              variant="light"
+              disabled={!shared}
+              onClick={() => copyToClipboard(shareUrl, 'Ссылка скопирована')}
+            >
+              Копировать
             </Button>
           </Group>
         </div>

--- a/frontend/src/v2/pages/editor/ui/EditorPage.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorPage.tsx
@@ -290,6 +290,9 @@ export default function EditorPage() {
         username={shareUsername}
         slug={slug ?? 'draft'}
         saved={snippetIdRef.current != null || slug != null}
+        snippetId={snippetQuery.data?.id ?? snippetIdRef.current ?? null}
+        shortCode={snippetQuery.data?.shortCode ?? null}
+        visibility={snippetQuery.data?.visibility ?? null}
       />
       <AddPackageModal
         opened={packageOpened}

--- a/frontend/src/v2/pages/embed/ui/EmbedPage.tsx
+++ b/frontend/src/v2/pages/embed/ui/EmbedPage.tsx
@@ -17,7 +17,11 @@ import {
 } from '../../../shared/runner';
 import { isPreviewLanguage } from '../../../shared/runner/preview';
 import HtmlPreview from '../../../shared/ui/HtmlPreview';
-import { type Snippet, useSnippetBySlug } from '../../../entities/snippet';
+import {
+  type Snippet,
+  useSnippetBySlug,
+  useSnippetByShortCode,
+} from '../../../entities/snippet';
 import { useTRPCClient } from '../../../shared/api';
 
 // Компактный embed-виджет (без AppHeader/AppFooter — страница живёт внутри iframe).
@@ -41,7 +45,7 @@ function lineColor(type: string): string {
 }
 
 export default function EmbedPage() {
-  const { username = '', slug = '' } = useParams();
+  const { username = '', slug = '', shortCode } = useParams();
   const [searchParams] = useSearchParams();
 
   const theme = searchParams.get('theme') === 'dark' ? 'dark' : 'light';
@@ -55,11 +59,14 @@ export default function EmbedPage() {
   const [runKey, setRunKey] = useState(0);
   const trpc = useTRPCClient();
 
+  // Источник данных зависит от вида ссылки: короткая /s/:code или /s/:user/:slug.
+  const byShortCode = useSnippetByShortCode(shortCode);
+  const bySlug = useSnippetBySlug(shortCode ? '' : username, shortCode ? '' : slug);
   const {
     data: snippet,
     isLoading,
     isError,
-  } = useSnippetBySlug(username, slug);
+  } = shortCode ? byShortCode : bySlug;
 
   // Палитра «рамки» виджета: тёмная или светлая по query-параметру theme.
   const frame =

--- a/frontend/src/v2/pages/share/ui/SharePage.tsx
+++ b/frontend/src/v2/pages/share/ui/SharePage.tsx
@@ -30,6 +30,7 @@ import {
   type Snippet,
   createSnippet,
   useSnippetBySlug,
+  useSnippetByShortCode,
 } from '../../../entities/snippet';
 
 /** Относительная дата по-русски: «сегодня», «вчера», «N дн. назад» либо locale-дата. */
@@ -46,17 +47,20 @@ export function relativeDate(iso: string | null | undefined): string {
 
 /** Публичная страница сниппета /s/:username/:slug. Показывает код, форк, встраивание, статистику. */
 export default function SharePage() {
-  const { username = '', slug = '' } = useParams();
+  const { username = '', slug = '', shortCode } = useParams();
   const navigate = useNavigate();
   const trpc = useTRPCClient();
   const { user, isGuest } = useSession();
   const auth = useAuthModal();
 
+  // Источник данных зависит от вида ссылки: короткая /s/:code или /s/:user/:slug.
+  const byShortCode = useSnippetByShortCode(shortCode);
+  const bySlug = useSnippetBySlug(shortCode ? '' : username, shortCode ? '' : slug);
   const {
     data: snippet,
     isLoading,
     isError,
-  } = useSnippetBySlug(username, slug);
+  } = shortCode ? byShortCode : bySlug;
 
   const forkMutation = useMutation({
     mutationFn: async (s: Snippet) =>

--- a/frontend/src/v2/shared/runner/index.ts
+++ b/frontend/src/v2/shared/runner/index.ts
@@ -1,9 +1,9 @@
 import { runJavaScript } from './javascript';
-import { type RunnerClient, runOnServer } from './server';
+import { type RunnerClient, type ServerLanguage, runOnServer } from './server';
 import type { RunResult } from './types';
 
 export type { ConsoleLine, RunResult } from './types';
-export type { RunnerClient, ServerRunOutput } from './server';
+export type { RunnerClient, ServerLanguage, ServerRunOutput } from './server';
 export { runJavaScript } from './javascript';
 export { toRunResult } from './server';
 
@@ -56,7 +56,8 @@ export async function runCode(params: RunCodeParams): Promise<RunResult> {
         durationMs: 0,
       };
     }
-    return runOnServer(client, { language, code, stdin });
+    // Принадлежность к SERVER_LANGUAGES проверена строкой выше.
+    return runOnServer(client, { language: language as ServerLanguage, code, stdin });
   }
 
   return unsupportedLanguage(language);

--- a/frontend/src/v2/shared/runner/server.ts
+++ b/frontend/src/v2/shared/runner/server.ts
@@ -4,29 +4,50 @@ import type { ConsoleLine, RunResult } from './types';
 // Бэкенд запускает код в изолированном docker-контейнере и возвращает stdout/stderr
 // раздельно, поэтому ошибки можно покрасить.
 
-/** Минимальный контракт ответа бэкенда (src/runner/types.ts). */
+/**
+ * Контракт ответа бэкенда (src/runner/types.ts).
+ *
+ * Поля опциональные не случайно: tRPC описывает ответ как JSON-совместимый тип,
+ * где nullable-поля становятся необязательными. Читаем их со значениями по
+ * умолчанию, чтобы неполный ответ не ломал интерфейс.
+ */
 export interface ServerRunOutput {
-  status:
+  status?:
     | 'ok'
     | 'timeout'
     | 'output_limit'
     | 'unavailable'
     | 'busy'
     | 'internal_error';
-  stdout: string;
-  stderr: string;
-  exitCode: number | null;
-  durationMs: number;
-  truncated: boolean;
-  message: string | null;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  durationMs?: number;
+  truncated?: boolean;
+  message?: string | null;
 }
+
+/**
+ * Языки, которые исполняет сервер. Union обязан совпадать с RUNNER_LANGUAGES
+ * на бэкенде: иначе типы tRPC-процедуры и этого клиента разъезжаются.
+ */
+export type ServerLanguage =
+  | 'python'
+  | 'php'
+  | 'ruby'
+  | 'java'
+  | 'typescript'
+  | 'go'
+  | 'cpp'
+  | 'sql'
+  | 'bash';
 
 /** Клиент передаётся аргументом, чтобы shared/ не зависел от React-хуков. */
 export interface RunnerClient {
   runner: {
     run: {
       mutate: (
-        input: { language: string; code: string; stdin?: string },
+        input: { language: ServerLanguage; code: string; stdin?: string },
         opts?: { signal?: AbortSignal },
       ) => Promise<ServerRunOutput>;
     };
@@ -44,29 +65,28 @@ const toLines = (raw: string, type: ConsoleLine['type']): ConsoleLine[] => {
 
 export function toRunResult(out: ServerRunOutput): RunResult {
   const lines: ConsoleLine[] = [];
+  const status = out.status ?? 'internal_error';
+  const stdout = out.stdout ?? '';
+  const stderr = out.stderr ?? '';
 
   // Инфраструктурные статусы: подсказку показываем первой строкой.
-  if (
-    out.status === 'unavailable' ||
-    out.status === 'busy' ||
-    out.status === 'internal_error'
-  ) {
+  if (status === 'unavailable' || status === 'busy' || status === 'internal_error') {
     lines.push({
       type: 'system',
       text: out.message ?? 'Серверное исполнение недоступно.',
     });
   }
 
-  lines.push(...toLines(out.stdout, 'log'));
-  lines.push(...toLines(out.stderr, 'error'));
+  lines.push(...toLines(stdout, 'log'));
+  lines.push(...toLines(stderr, 'error'));
 
-  if (out.status === 'timeout') {
+  if (status === 'timeout') {
     lines.push({
       type: 'error',
       text: out.message ?? 'Превышен лимит времени',
     });
   }
-  if (out.status === 'output_limit' || (out.status === 'ok' && out.truncated)) {
+  if (status === 'output_limit' || (status === 'ok' && out.truncated)) {
     lines.push({
       type: 'system',
       text: out.message ?? 'Вывод обрезан',
@@ -75,14 +95,14 @@ export function toRunResult(out: ServerRunOutput): RunResult {
 
   return {
     lines,
-    exitCode: out.exitCode ?? (out.status === 'timeout' ? 124 : 1),
-    durationMs: out.durationMs,
+    exitCode: out.exitCode ?? (status === 'timeout' ? 124 : 1),
+    durationMs: out.durationMs ?? 0,
   };
 }
 
 export async function runOnServer(
   client: RunnerClient,
-  params: { language: string; code: string; stdin?: string },
+  params: { language: ServerLanguage; code: string; stdin?: string },
   /** Клиентский таймаут с запасом над серверным (java — 20 c). */
   timeoutMs = 30_000,
 ): Promise<RunResult> {

--- a/src/db/schema/schema.ts
+++ b/src/db/schema/schema.ts
@@ -38,6 +38,19 @@ export const snippets = sqliteTable('snippets', {
   slug: text('slug', { length: 30 }),
   code: text('code').notNull(),
   language: text('language', { length: 50 }),
+  /**
+   * Короткий код для публичной ссылки вида /s/aB3xK9 — им делятся и по нему
+   * встраивают сниппет. Уникален глобально (в отличие от slug, который
+   * уникален только внутри пользователя).
+   */
+  shortCode: text('short_code', { length: 16 }).unique(),
+  /**
+   * Кто может открыть сниппет:
+   *  private — только владелец;
+   *  link    — любой, у кого есть ссылка (в поиске и профиле не показывается);
+   *  public  — виден всем, попадает в публичный профиль.
+   */
+  visibility: text('visibility', { length: 10 }).notNull().default('private'),
   userId: integer('user_id').references(() => users.id, {
     onDelete: 'cascade',
   }),

--- a/src/db/snippets.ts
+++ b/src/db/snippets.ts
@@ -34,6 +34,18 @@ export const snippetSchema = z.object({
   updatedAt: z.date(),
 });
 
+/** Уровни доступа к сниппету. */
+export const VISIBILITIES = ['private', 'link', 'public'] as const;
+export const visibilitySchema = z.enum(VISIBILITIES);
+export type Visibility = (typeof VISIBILITIES)[number];
+
+export const getSnippetByShortCodeSchema = z.string().min(4).max(16);
+
+export const setVisibilitySchema = z.object({
+  id: z.number(),
+  visibility: visibilitySchema,
+});
+
 export const createSnippetSchema = z.object({
   name: z.string().min(1).max(30),
   code: z.string().min(1),
@@ -53,6 +65,7 @@ export const createSnippetSchema = z.object({
     'css',
   ]),
   userId: z.number().positive(),
+  visibility: visibilitySchema.optional(),
 });
 
 export const updateSnippetSchema = createSnippetSchema.partial().extend({
@@ -148,6 +161,77 @@ export async function getAllSnippets(): Promise<Snippet[]> {
 }
 
 // по id юзера создание сниппета
+
+/**
+ * Короткий код для публичной ссылки (/s/aB3xK9).
+ *
+ * Алфавит без похожих символов (0/O, 1/l/I), чтобы код можно было продиктовать
+ * или перепечатать вручную. Уникальность проверяем запросом: коллизия на
+ * 6 символах маловероятна, но обязана быть исключена — по коду открывается
+ * чужой сниппет.
+ */
+const SHORT_CODE_ALPHABET =
+  'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+async function generateShortCode(length = 6): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    let code = '';
+    for (let i = 0; i < length; i += 1) {
+      code +=
+        SHORT_CODE_ALPHABET[
+          Math.floor(Math.random() * SHORT_CODE_ALPHABET.length)
+        ];
+    }
+    const [taken] = await db
+      .select({ id: snippets.id })
+      .from(snippets)
+      .where(eq(snippets.shortCode, code))
+      .limit(1);
+    if (!taken) return code;
+  }
+  // Практически недостижимо; удлиняем код, вместо того чтобы падать.
+  return generateShortCode(length + 2);
+}
+
+/** Сниппет по короткой ссылке. Приватные по коду не отдаём. */
+export async function getSnippetByShortCode(
+  shortCode: string,
+): Promise<(Snippet & { authorUsername: string | null }) | undefined> {
+  try {
+    const [row] = await db
+      .select({ snippet: snippets, username: users.username })
+      .from(snippets)
+      .leftJoin(users, eq(snippets.userId, users.id))
+      .where(eq(snippets.shortCode, shortCode))
+      .limit(1);
+
+    if (!row || row.snippet.visibility === 'private') return undefined;
+    return { ...row.snippet, authorUsername: row.username ?? null };
+  } catch (error) {
+    console.error('Error in getSnippetByShortCode:', error);
+    throw new Error('Failed to get snippet by short code');
+  }
+}
+
+/** Смена уровня доступа. */
+export async function setSnippetVisibility(
+  id: number,
+  visibility: Visibility,
+): Promise<Snippet> {
+  try {
+    const [result] = await db
+      .update(snippets)
+      .set({ visibility, updatedAt: new Date() })
+      .where(eq(snippets.id, id))
+      .returning();
+    if (!result) throw new Error(`Snippet with id ${id} not found`);
+    return result;
+  } catch (error) {
+    console.error('Error in setSnippetVisibility:', error);
+    throw new Error('Failed to update snippet visibility');
+  }
+}
+
 export async function createSnippet(
   snippetData: CreateSnippetInput,
 ): Promise<Snippet> {
@@ -163,6 +247,9 @@ export async function createSnippet(
       code: snippetData.code,
       language: snippetData.language,
       slug,
+      shortCode: await generateShortCode(),
+      // По умолчанию приватный: публикация — осознанное действие автора.
+      visibility: snippetData.visibility ?? 'private',
       userId: snippetData.userId,
     };
     const [result] = await db

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { fastify } from 'fastify';
 import { runMigrations } from './db/connection';
 import { seedHomePageData } from './db/seedHomePageData';
 import { registerHealthRoute } from './health';
+import { registerOembedRoutes } from './oembed';
 import { type AppRouter, appRouter } from './router/index';
 
 // import { createContext } from './context';
@@ -51,6 +52,7 @@ const getApp = async () => {
   });
 
   registerHealthRoute(server);
+  registerOembedRoutes(server);
 
   server.get('/hello', async (_request, reply) => {
     reply.type('text/plain').send('Hello world');

--- a/src/oembed.ts
+++ b/src/oembed.ts
@@ -1,0 +1,173 @@
+import type { FastifyInstance } from 'fastify';
+import { getSnippetByShortCode } from './db/snippets';
+
+/**
+ * Встраивание «просто по ссылке» — как у YouTube.
+ *
+ * Работает это так: площадка (WordPress, Notion, Discourse, Slack и др.) получает
+ * ссылку на сниппет и запрашивает у нас oEmbed-описание, а мы возвращаем готовый
+ * HTML виджета. Пользователю достаточно вставить ссылку — iframe он не пишет.
+ *
+ * Здесь три части:
+ *  1. GET /oembed — сам oEmbed-эндпоинт (спецификация oembed.com);
+ *  2. GET /s/:shortCode/meta — HTML с Open Graph и ссылкой на oEmbed (discovery):
+ *     по нему площадки и мессенджеры разворачивают превью. Отдаём его ботам —
+ *     людям Caddy отдаёт SPA (см. frontend/Caddyfile.docker);
+ *  3. общие размеры виджета по умолчанию.
+ */
+
+const DEFAULT_WIDTH = 640;
+const DEFAULT_HEIGHT = 380;
+const MIN_HEIGHT = 200;
+const MAX_HEIGHT = 900;
+
+/** Экранирование для вставки в HTML-атрибуты и текст метатегов. */
+const esc = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/** Публичный адрес сервиса: за прокси берём заголовки, иначе — из запроса. */
+const baseUrlFrom = (
+  headers: Record<string, unknown>,
+  fallback: string,
+): string => {
+  const envBase = process.env.PUBLIC_BASE_URL;
+  if (envBase) return envBase.replace(/\/$/, '');
+  const host = String(headers['x-forwarded-host'] ?? headers.host ?? '');
+  const forwarded = String(headers['x-forwarded-proto'] ?? '').split(',')[0];
+  // За прокси доверяем заголовку; локальная разработка идёт по http, прод — https.
+  const proto =
+    forwarded ||
+    (/^(localhost|127\.0\.0\.1)(:|$)/.test(host) ? 'http' : 'https');
+  return host ? `${proto}://${host}` : fallback;
+};
+
+/** Достаёт короткий код из ссылки вида https://host/s/aB3xK9. */
+const shortCodeFromUrl = (raw: string): string | null => {
+  try {
+    const url = new URL(raw);
+    const match = url.pathname.match(/\/s\/([A-Za-z0-9]{4,16})\/?$/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+};
+
+export function registerOembedRoutes(server: FastifyInstance): void {
+  // ---------- 1. oEmbed ----------
+  server.get('/oembed', async (request, reply) => {
+    const query = request.query as Record<string, string | undefined>;
+    const { url, format, maxwidth, maxheight } = query;
+
+    if (format && format !== 'json') {
+      // XML-формат по спецификации допустим, но нам не нужен: все актуальные
+      // площадки умеют json.
+      return reply
+        .code(501)
+        .send({ error: 'Поддерживается только format=json' });
+    }
+    if (!url) return reply.code(400).send({ error: 'Не передан параметр url' });
+
+    const shortCode = shortCodeFromUrl(url);
+    if (!shortCode)
+      return reply
+        .code(404)
+        .send({ error: 'Ссылка не похожа на сниппет Runit' });
+
+    const snippet = await getSnippetByShortCode(shortCode);
+    // 404 и для приватных: существование приватного сниппета — тоже информация.
+    if (!snippet) return reply.code(404).send({ error: 'Сниппет не найден' });
+
+    const base = baseUrlFrom(
+      request.headers as Record<string, unknown>,
+      'https://runit.hexlet.io',
+    );
+    const width = clamp(Number(maxwidth) || DEFAULT_WIDTH, 240, 1600);
+    const height = clamp(
+      Number(maxheight) || DEFAULT_HEIGHT,
+      MIN_HEIGHT,
+      MAX_HEIGHT,
+    );
+    const embedUrl = `${base}/embed/s/${shortCode}`;
+
+    return reply.header('cache-control', 'public, max-age=300').send({
+      version: '1.0',
+      type: 'rich',
+      provider_name: 'Runit',
+      provider_url: base,
+      title: snippet.name,
+      author_name: snippet.authorUsername ?? 'Runit',
+      author_url: snippet.authorUsername
+        ? `${base}/u/${snippet.authorUsername}`
+        : base,
+      width,
+      height,
+      html:
+        `<iframe src="${esc(embedUrl)}" width="${width}" height="${height}" ` +
+        `style="border:0;border-radius:12px" loading="lazy" ` +
+        `title="${esc(snippet.name)} — Runit" allow="clipboard-write"></iframe>`,
+    });
+  });
+
+  // ---------- 2. HTML с метатегами (для ботов и мессенджеров) ----------
+  server.get('/s/:shortCode/meta', async (request, reply) => {
+    const { shortCode } = request.params as { shortCode: string };
+    const snippet = await getSnippetByShortCode(shortCode);
+    if (!snippet)
+      return reply
+        .code(404)
+        .type('text/html')
+        .send('<!doctype html><title>Не найдено</title>');
+
+    const base = baseUrlFrom(
+      request.headers as Record<string, unknown>,
+      'https://runit.hexlet.io',
+    );
+    const pageUrl = `${base}/s/${shortCode}`;
+    const embedUrl = `${base}/embed/s/${shortCode}`;
+    const author = snippet.authorUsername ?? 'Runit';
+    const title = `${snippet.name} — Runit`;
+    const description = `Сниппет на ${snippet.language ?? 'коде'} от @${author}: смотрите и запускайте прямо в браузере.`;
+
+    return reply.type('text/html; charset=utf-8').send(`<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<title>${esc(title)}</title>
+<meta name="description" content="${esc(description)}">
+<link rel="canonical" href="${esc(pageUrl)}">
+
+<!-- Встраивание по ссылке: площадка находит oEmbed через этот link -->
+<link rel="alternate" type="application/json+oembed"
+      href="${esc(`${base}/oembed?url=${encodeURIComponent(pageUrl)}&format=json`)}"
+      title="${esc(snippet.name)}">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Runit">
+<meta property="og:title" content="${esc(title)}">
+<meta property="og:description" content="${esc(description)}">
+<meta property="og:url" content="${esc(pageUrl)}">
+
+<!-- Плеер: мессенджеры и соцсети показывают рабочий виджет, а не просто ссылку -->
+<meta name="twitter:card" content="player">
+<meta name="twitter:title" content="${esc(title)}">
+<meta name="twitter:description" content="${esc(description)}">
+<meta name="twitter:player" content="${esc(embedUrl)}">
+<meta name="twitter:player:width" content="${DEFAULT_WIDTH}">
+<meta name="twitter:player:height" content="${DEFAULT_HEIGHT}">
+</head>
+<body>
+<h1>${esc(snippet.name)}</h1>
+<p>${esc(description)}</p>
+<p><a href="${esc(pageUrl)}">Открыть сниппет в Runit</a></p>
+</body>
+</html>`);
+  });
+}

--- a/src/router/snippetRouter.ts
+++ b/src/router/snippetRouter.ts
@@ -8,8 +8,12 @@ import {
   getAllSnippets,
   getSnippetById,
   getSnippetByIdSchema,
+  getSnippetByShortCode,
+  getSnippetByShortCodeSchema,
   getSnippetByUsernameSlug,
   getSnippetByUsernameSlugSchema,
+  setSnippetVisibility,
+  setVisibilitySchema,
   updateSnippet,
   updateSnippetSchema,
 } from '../db/snippets';
@@ -73,6 +77,28 @@ export const snippetRouter = router({
 
       return { success: true, id: input.id };
     }),
+
+  /** Сниппет по короткой ссылке /s/:code. Приватные не отдаются. */
+  getSnippetByShortCode: publicProcedure
+    .input(getSnippetByShortCodeSchema)
+    .query(async ({ input }) => {
+      const snippet = await getSnippetByShortCode(input);
+      if (!snippet) {
+        throw new Error('Snippet not found');
+      }
+      return snippet;
+    }),
+
+  /**
+   * Публикация и снятие публикации.
+   * TODO(#792): проверять, что текущий пользователь — владелец, как только
+   * появится авторизация.
+   */
+  setVisibility: publicProcedure
+    .input(setVisibilitySchema)
+    .mutation(async ({ input }) =>
+      setSnippetVisibility(input.id, input.visibility),
+    ),
 
   generateSnippetName: publicProcedure.query(() => {
     return { name: generateName() };

--- a/types/db/schema/schema.d.ts
+++ b/types/db/schema/schema.d.ts
@@ -378,6 +378,44 @@ export declare const snippets: import("drizzle-orm/sqlite-core").SQLiteTableWith
         }, {}, {
             length: 50;
         }>;
+        shortCode: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "short_code";
+            tableName: "snippets";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: false;
+            hasDefault: false;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: 16;
+        }>;
+        visibility: import("drizzle-orm/sqlite-core").SQLiteColumn<{
+            name: "visibility";
+            tableName: "snippets";
+            dataType: "string";
+            columnType: "SQLiteText";
+            data: string;
+            driverParam: string;
+            notNull: true;
+            hasDefault: true;
+            isPrimaryKey: false;
+            isAutoincrement: false;
+            hasRuntimeDefault: false;
+            enumValues: [string, ...string[]];
+            baseColumn: never;
+            identity: undefined;
+            generated: undefined;
+        }, {}, {
+            length: 10;
+        }>;
         userId: import("drizzle-orm/sqlite-core").SQLiteColumn<{
             name: "user_id";
             tableName: "snippets";

--- a/types/db/snippets.d.ts
+++ b/types/db/snippets.d.ts
@@ -15,7 +15,7 @@ export declare const snippetSchema: z.ZodObject<{
     createdAt: Date;
     updatedAt: Date;
     userId: number;
-    language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+    language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
     slug: string | null;
     code: string;
 }, {
@@ -24,9 +24,24 @@ export declare const snippetSchema: z.ZodObject<{
     createdAt: Date;
     updatedAt: Date;
     userId: number;
-    language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+    language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
     slug: string | null;
     code: string;
+}>;
+/** Уровни доступа к сниппету. */
+export declare const VISIBILITIES: readonly ["private", "link", "public"];
+export declare const visibilitySchema: z.ZodEnum<["private", "link", "public"]>;
+export type Visibility = (typeof VISIBILITIES)[number];
+export declare const getSnippetByShortCodeSchema: z.ZodString;
+export declare const setVisibilitySchema: z.ZodObject<{
+    id: z.ZodNumber;
+    visibility: z.ZodEnum<["private", "link", "public"]>;
+}, "strip", z.ZodTypeAny, {
+    id: number;
+    visibility: "link" | "private" | "public";
+}, {
+    id: number;
+    visibility: "link" | "private" | "public";
 }>;
 export declare const createSnippetSchema: z.ZodObject<{
     name: z.ZodString;
@@ -34,18 +49,21 @@ export declare const createSnippetSchema: z.ZodObject<{
     slug: z.ZodOptional<z.ZodString>;
     language: z.ZodEnum<["javascript", "typescript", "python", "php", "ruby", "java", "go", "cpp", "sql", "bash", "html", "css"]>;
     userId: z.ZodNumber;
+    visibility: z.ZodOptional<z.ZodEnum<["private", "link", "public"]>>;
 }, "strip", z.ZodTypeAny, {
     name: string;
     userId: number;
-    language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+    language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
     code: string;
     slug?: string | undefined;
+    visibility?: "link" | "private" | "public" | undefined;
 }, {
     name: string;
     userId: number;
-    language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+    language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
     code: string;
     slug?: string | undefined;
+    visibility?: "link" | "private" | "public" | undefined;
 }>;
 export declare const updateSnippetSchema: z.ZodObject<{
     name: z.ZodOptional<z.ZodString>;
@@ -53,22 +71,25 @@ export declare const updateSnippetSchema: z.ZodObject<{
     slug: z.ZodOptional<z.ZodOptional<z.ZodString>>;
     language: z.ZodOptional<z.ZodEnum<["javascript", "typescript", "python", "php", "ruby", "java", "go", "cpp", "sql", "bash", "html", "css"]>>;
     userId: z.ZodOptional<z.ZodNumber>;
+    visibility: z.ZodOptional<z.ZodOptional<z.ZodEnum<["private", "link", "public"]>>>;
 } & {
     id: z.ZodNumber;
 }, "strip", z.ZodTypeAny, {
     id: number;
     name?: string | undefined;
     userId?: number | undefined;
-    language?: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css" | undefined;
+    language?: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css" | undefined;
     slug?: string | undefined;
     code?: string | undefined;
+    visibility?: "link" | "private" | "public" | undefined;
 }, {
     id: number;
     name?: string | undefined;
     userId?: number | undefined;
-    language?: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css" | undefined;
+    language?: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css" | undefined;
     slug?: string | undefined;
     code?: string | undefined;
+    visibility?: "link" | "private" | "public" | undefined;
 }>;
 export declare const getSnippetByIdSchema: z.ZodNumber;
 export declare const deleteSnippetSchema: z.ZodObject<{
@@ -93,6 +114,12 @@ export type UpdateSnippetInput = z.infer<typeof updateSnippetSchema>;
 export declare function getSnippetById(id: number): Promise<Snippet | undefined>;
 export declare function getSnippetByUsernameSlug(username: string, slug: string): Promise<Snippet | undefined>;
 export declare function getAllSnippets(): Promise<Snippet[]>;
+/** Сниппет по короткой ссылке. Приватные по коду не отдаём. */
+export declare function getSnippetByShortCode(shortCode: string): Promise<(Snippet & {
+    authorUsername: string | null;
+}) | undefined>;
+/** Смена уровня доступа. */
+export declare function setSnippetVisibility(id: number, visibility: Visibility): Promise<Snippet>;
 export declare function createSnippet(snippetData: CreateSnippetInput): Promise<Snippet>;
 export declare function updateSnippet(id: number, updates: Omit<UpdateSnippetInput, 'id' | 'userId'>): Promise<Snippet>;
 export declare function deleteSnippet(id: number): Promise<boolean>;

--- a/types/health.d.ts
+++ b/types/health.d.ts
@@ -1,0 +1,10 @@
+import type { FastifyInstance } from 'fastify';
+/**
+ * Health-check для оркестратора и аптайм-мониторинга (#896).
+ *
+ * Проверяет не только «процесс жив», но и доступность БД: приложение без базы
+ * бесполезно, и балансировщик должен убрать такой инстанс из ротации.
+ *
+ * 200 — всё в порядке, 503 — БД недоступна.
+ */
+export declare function registerHealthRoute(server: FastifyInstance): void;

--- a/types/oembed.d.ts
+++ b/types/oembed.d.ts
@@ -1,0 +1,2 @@
+import type { FastifyInstance } from 'fastify';
+export declare function registerOembedRoutes(server: FastifyInstance): void;

--- a/types/router/index.d.ts
+++ b/types/router/index.d.ts
@@ -166,6 +166,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                     language: string | null;
                     slug: string | null;
                     code: string;
+                    shortCode: string | null;
+                    visibility: string;
                 } & {
                     user: import("../db/schema/schema").User;
                 })[];
@@ -190,6 +192,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             };
             meta: object;
         }>;
@@ -207,6 +211,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             };
             meta: object;
         }>;
@@ -221,6 +227,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             }[];
             meta: object;
         }>;
@@ -228,9 +236,10 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
             input: {
                 name: string;
                 userId: number;
-                language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+                language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
                 code: string;
                 slug?: string | undefined;
+                visibility?: "link" | "private" | "public" | undefined;
             };
             output: {
                 id: number;
@@ -241,6 +250,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             };
             meta: object;
         }>;
@@ -249,9 +260,10 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 id: number;
                 name?: string | undefined;
                 userId?: number | undefined;
-                language?: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css" | undefined;
+                language?: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css" | undefined;
                 slug?: string | undefined;
                 code?: string | undefined;
+                visibility?: "link" | "private" | "public" | undefined;
             };
             output: {
                 id: number;
@@ -262,6 +274,8 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             };
             meta: object;
         }>;
@@ -272,6 +286,43 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
             output: {
                 success: boolean;
                 id: number;
+            };
+            meta: object;
+        }>;
+        getSnippetByShortCode: import("@trpc/server").TRPCQueryProcedure<{
+            input: string;
+            output: {
+                id: number;
+                name: string;
+                createdAt: Date;
+                updatedAt: Date;
+                userId: number | null;
+                language: string | null;
+                slug: string | null;
+                code: string;
+                shortCode: string | null;
+                visibility: string;
+            } & {
+                authorUsername: string | null;
+            };
+            meta: object;
+        }>;
+        setVisibility: import("@trpc/server").TRPCMutationProcedure<{
+            input: {
+                id: number;
+                visibility: "link" | "private" | "public";
+            };
+            output: {
+                id: number;
+                name: string;
+                createdAt: Date;
+                updatedAt: Date;
+                userId: number | null;
+                language: string | null;
+                slug: string | null;
+                code: string;
+                shortCode: string | null;
+                visibility: string;
             };
             meta: object;
         }>;
@@ -363,7 +414,7 @@ export declare const appRouter: import("@trpc/server").TRPCBuiltRouter<{
     }, import("@trpc/server").TRPCDecorateCreateRouterOptions<{
         run: import("@trpc/server").TRPCMutationProcedure<{
             input: {
-                language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash";
+                language: "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash";
                 code: string;
                 stdin?: string | undefined;
             };

--- a/types/router/runnerRouter.d.ts
+++ b/types/router/runnerRouter.d.ts
@@ -14,7 +14,7 @@ export declare const runnerRouter: import("@trpc/server").TRPCBuiltRouter<{
      */
     run: import("@trpc/server").TRPCMutationProcedure<{
         input: {
-            language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash";
+            language: "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash";
             code: string;
             stdin?: string | undefined;
         };

--- a/types/router/snippetRouter.d.ts
+++ b/types/router/snippetRouter.d.ts
@@ -15,6 +15,8 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             language: string | null;
             slug: string | null;
             code: string;
+            shortCode: string | null;
+            visibility: string;
         };
         meta: object;
     }>;
@@ -32,6 +34,8 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             language: string | null;
             slug: string | null;
             code: string;
+            shortCode: string | null;
+            visibility: string;
         };
         meta: object;
     }>;
@@ -46,6 +50,8 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             language: string | null;
             slug: string | null;
             code: string;
+            shortCode: string | null;
+            visibility: string;
         }[];
         meta: object;
     }>;
@@ -53,9 +59,10 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
         input: {
             name: string;
             userId: number;
-            language: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css";
+            language: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css";
             code: string;
             slug?: string | undefined;
+            visibility?: "link" | "private" | "public" | undefined;
         };
         output: {
             id: number;
@@ -66,6 +73,8 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             language: string | null;
             slug: string | null;
             code: string;
+            shortCode: string | null;
+            visibility: string;
         };
         meta: object;
     }>;
@@ -74,9 +83,10 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             id: number;
             name?: string | undefined;
             userId?: number | undefined;
-            language?: "python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash" | "javascript" | "html" | "css" | undefined;
+            language?: "javascript" | "typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash" | "html" | "css" | undefined;
             slug?: string | undefined;
             code?: string | undefined;
+            visibility?: "link" | "private" | "public" | undefined;
         };
         output: {
             id: number;
@@ -87,6 +97,8 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
             language: string | null;
             slug: string | null;
             code: string;
+            shortCode: string | null;
+            visibility: string;
         };
         meta: object;
     }>;
@@ -97,6 +109,49 @@ export declare const snippetRouter: import("@trpc/server").TRPCBuiltRouter<{
         output: {
             success: boolean;
             id: number;
+        };
+        meta: object;
+    }>;
+    /** Сниппет по короткой ссылке /s/:code. Приватные не отдаются. */
+    getSnippetByShortCode: import("@trpc/server").TRPCQueryProcedure<{
+        input: string;
+        output: {
+            id: number;
+            name: string;
+            createdAt: Date;
+            updatedAt: Date;
+            userId: number | null;
+            language: string | null;
+            slug: string | null;
+            code: string;
+            shortCode: string | null;
+            visibility: string;
+        } & {
+            authorUsername: string | null;
+        };
+        meta: object;
+    }>;
+    /**
+     * Публикация и снятие публикации.
+     * TODO(#792): проверять, что текущий пользователь — владелец, как только
+     * появится авторизация.
+     */
+    setVisibility: import("@trpc/server").TRPCMutationProcedure<{
+        input: {
+            id: number;
+            visibility: "link" | "private" | "public";
+        };
+        output: {
+            id: number;
+            name: string;
+            createdAt: Date;
+            updatedAt: Date;
+            userId: number | null;
+            language: string | null;
+            slug: string | null;
+            code: string;
+            shortCode: string | null;
+            visibility: string;
         };
         meta: object;
     }>;

--- a/types/router/userRouter.d.ts
+++ b/types/router/userRouter.d.ts
@@ -160,6 +160,8 @@ export declare const userRouter: import("@trpc/server").TRPCBuiltRouter<{
                 language: string | null;
                 slug: string | null;
                 code: string;
+                shortCode: string | null;
+                visibility: string;
             } & {
                 user: import("../db/schema/schema").User;
             })[];

--- a/types/runner/config.d.ts
+++ b/types/runner/config.d.ts
@@ -5,7 +5,7 @@ export declare const runnerConfig: {
     imageTag: string;
     tmpDir: string;
     maxConcurrent: number;
-    enabledLanguages: ("python" | "php" | "ruby" | "java" | "typescript" | "go" | "cpp" | "sql" | "bash")[];
+    enabledLanguages: ("typescript" | "python" | "php" | "ruby" | "java" | "go" | "cpp" | "sql" | "bash")[];
     /** Базовые лимиты; на язык уточняются в languages.ts. */
     limits: {
         timeoutMs: number;

--- a/types/runner/index.d.ts
+++ b/types/runner/index.d.ts
@@ -4,11 +4,11 @@ export { runCode, sweepOrphans } from './run';
 export type { RunnerLanguage, RunOutput, RunStatus } from './types';
 export declare const runInputSchema: z.ZodObject<{
     language: z.ZodEnum<{
+        typescript: "typescript";
         python: "python";
         php: "php";
         ruby: "ruby";
         java: "java";
-        typescript: "typescript";
         go: "go";
         cpp: "cpp";
         sql: "sql";


### PR DESCRIPTION
Part of #643, #828

## Проблема

Шаринг был декоративным: тумблер «Доступ по ссылке» в модалке **ничего не сохранял**, а полей `visibility` и `shortCode` в БД **не существовало вовсе**. Следствия: все сниппеты фактически публичны (черновик не спрятать), ссылки только длинные `/s/:username/:slug`, а обещанных в дизайне коротких `/s/aB3xK9` нет.

## Данные

* `snippets.shortCode` — уникальный глобально; генерируется из алфавита без похожих символов (`0/O`, `1/l/I`), чтобы код можно было продиктовать, **с проверкой коллизий**: по коду открывается чужой сниппет, поэтому уникальность обязана быть гарантирована, а не вероятна.
* `snippets.visibility` — `private | link | public`, по умолчанию **private**: публикация должна быть осознанным действием автора, а не побочным эффектом создания.
* Процедуры `snippets.getSnippetByShortCode` (приватные не отдаёт) и `snippets.setVisibility`.

## Встраивание по ссылке — как у YouTube

Главное новое: чтобы вставить сниппет, больше не нужно копировать `<iframe>`.

* **`GET /oembed`** по спецификации [oembed.com](https://oembed.com): площадка получает ссылку и запрашивает у нас описание, мы отдаём готовый html виджета. В WordPress, Notion, Discourse, Slack достаточно вставить ссылку.
* **`GET /s/:shortCode/meta`** — HTML с Open Graph, `twitter:player` и discovery-ссылкой на oEmbed. Caddy направляет туда **ботов**, а людям отдаёт приложение: SPA-оболочка без метатегов в превью не разворачивается — это классическая проблема SPA, решена маршрутизацией по User-Agent.
* Приватные сниппеты дают **404 и в oEmbed, и в метатегах**: существование приватного сниппета — тоже информация.

## Фронтенд

* Роуты `/s/:shortCode` и `/embed/s/:shortCode`; длинные пути сохранены, старые ссылки не ломаются. Источник данных выбирается по виду ссылки.
* Модалка шаринга: тумблер **реально** меняет доступ, показывает честное состояние («Сниппет приватный — ссылка и встраивание не работают») и блокирует копирование, пока сниппет приватный. Добавлен блок «Или просто вставьте ссылку».

## Попутно исправлена типизация раннера

`RunnerClient` объявлял `language: string`, а tRPC ожидает union языков; поля ответа приходят опциональными. Контракт приведён к реальному и читается со значениями по умолчанию. Vite этого не ловил (не проверяет типы), строгий `tsc` — ловит.

## Проверка

Сквозной прогон в браузере на чистой БД:

1. новый сниппет создаётся **приватным**, короткая ссылка выдаётся сразу;
2. приватный по короткой ссылке **не открывается**;
3. в модалке видна честная подсказка и короткая ссылка, есть блок вставки по ссылке;
4. тумблер публикует → подпись меняется на «Просматривать могут все, у кого есть ссылка»;
5. короткая ссылка открывает страницу сниппета, `/embed/s/:code` — виджет;
6. `oEmbed` возвращает `type: rich` с готовым `<iframe>`; метатеги содержат `json+oembed`, `og:title`, `twitter:player`.

`npm run test:runner` — 28/28, `tsc --noEmit` и `biome` чисто, сборка фронта зелёная. 0 ошибок в консоли браузера.

## Что осталось по теме

Счётчики просмотров и форков, статистика «где встраивался» — #840. Отдельный лёгкий embed-бандл вместо загрузки всего SPA — #841. Проверка владельца при смене видимости — после появления авторизации (#792), в коде помечено TODO.