### PR TITLE
feat(security): заголовки безопасности и лимиты частоты запросов

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,3 +63,40 @@ jobs:
       - name: Образ фронтенда
         # Контекст — корень репозитория: фронту нужны типы из types/.
         run: docker build -f frontend/Dockerfile -t runit-web:ci .
+
+  runner-smoke:
+    name: Раннер — исполнение 9 языков в Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Установка зависимостей
+        run: npm ci
+
+      - name: Сборка образов языков
+        # На раннере GitHub Actions Docker есть, поэтому happy path раннера
+        # проверяется здесь — у разработчика демон может быть выключен.
+        run: npm run runner:build-images
+
+      - name: Запуск сервера
+        run: |
+          DB_PATH=/tmp/ci.sqlite npx tsx src/server.ts &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3001/health >/dev/null && break
+            sleep 1
+          done
+          curl -sf http://localhost:3001/health
+
+      - name: Прогон языков, stdin, таймаута и изоляции сети
+        run: npm run runner:smoke
+
+      - name: Контейнеры не осиротели после таймаута
+        run: |
+          left=$(docker ps -aq --filter label=runit-runner | wc -l)
+          echo "оставшихся контейнеров раннера: $left"
+          test "$left" -eq 0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,6 +85,9 @@ jobs:
 
       - name: Запуск сервера
         run: |
+          # Миграции не в git (каталог drizzle/ в .gitignore), поэтому их нужно
+          # сгенерировать из схемы — иначе сервер падает на старте.
+          npm run db:generate
           DB_PATH=/tmp/ci.sqlite npx tsx src/server.ts &
           for i in $(seq 1 30); do
             curl -sf http://localhost:3001/health >/dev/null && break

--- a/bin/runner-smoke.mjs
+++ b/bin/runner-smoke.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Smoke-проверка серверного раннера: по одному сниппету на каждый язык.
+//
+// Запускается в CI, где есть Docker (локально у разработчика демон может быть
+// выключен — тогда раннер отвечает подсказкой, и проверять нечего).
+// Использование: node bin/runner-smoke.mjs [базовый-URL]
+
+const BASE = process.argv[2] ?? 'http://localhost:3001';
+
+const CASES = [
+  { language: 'python', code: "print('ok-python')", expect: 'ok-python' },
+  { language: 'php', code: "echo 'ok-php';", expect: 'ok-php' },
+  { language: 'ruby', code: "puts 'ok-ruby'", expect: 'ok-ruby' },
+  { language: 'bash', code: "echo ok-bash", expect: 'ok-bash' },
+  { language: 'typescript', code: "const s: string = 'ok-ts';\nconsole.log(s);", expect: 'ok-ts' },
+  { language: 'go', code: 'package main\nimport "fmt"\nfunc main() { fmt.Println("ok-go") }', expect: 'ok-go' },
+  {
+    language: 'cpp',
+    code: '#include <iostream>\nint main() { std::cout << "ok-cpp" << std::endl; }',
+    expect: 'ok-cpp',
+  },
+  { language: 'sql', code: "select 'ok-sql' as result;", expect: 'ok-sql' },
+  {
+    language: 'java',
+    code: 'class Main { public static void main(String[] a) { System.out.println("ok-java"); } }',
+    expect: 'ok-java',
+  },
+  // Проверяем не только happy path: ввод и защита от бесконечного цикла.
+  { language: 'python', code: 'print(input().upper())', stdin: 'stdin-works', expect: 'STDIN-WORKS', label: 'python + stdin' },
+  { language: 'python', code: 'while True: pass', expectStatus: 'timeout', label: 'python таймаут' },
+  {
+    language: 'python',
+    code: "import socket\ntry:\n    socket.create_connection(('1.1.1.1', 80), 3)\n    print('СЕТЬ ДОСТУПНА')\nexcept Exception as e:\n    print('сеть недоступна')",
+    expect: 'сеть недоступна',
+    label: 'изоляция сети',
+  },
+];
+
+const run = async (item) => {
+  const response = await fetch(`${BASE}/trpc/runner.run`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ language: item.language, code: item.code, stdin: item.stdin ?? '' }),
+  });
+  const json = await response.json();
+  if (json.error) throw new Error(`tRPC: ${JSON.stringify(json.error).slice(0, 200)}`);
+  return json.result.data;
+};
+
+const main = async () => {
+  let failed = 0;
+
+  for (const item of CASES) {
+    const label = item.label ?? item.language;
+    try {
+      const out = await run(item);
+      const output = `${out.stdout ?? ''}${out.stderr ?? ''}`;
+
+      if (item.expectStatus) {
+        const ok = out.status === item.expectStatus;
+        console.log(`${ok ? '✓' : '✗'} ${label}: status=${out.status} (ожидали ${item.expectStatus})`);
+        if (!ok) failed += 1;
+        continue;
+      }
+
+      const ok = out.status === 'ok' && output.includes(item.expect);
+      console.log(
+        `${ok ? '✓' : '✗'} ${label}: status=${out.status} exit=${out.exitCode} ` +
+          `${out.durationMs}ms ${ok ? '' : `вывод: ${output.slice(0, 160).replace(/\n/g, ' | ')}`}`,
+      );
+      if (!ok) failed += 1;
+    } catch (error) {
+      console.log(`✗ ${label}: ${error.message}`);
+      failed += 1;
+    }
+  }
+
+  console.log(`\nИтого: ${CASES.length - failed} из ${CASES.length}`);
+  if (failed > 0) process.exit(1);
+};
+
+main();

--- a/frontend/Caddyfile.docker
+++ b/frontend/Caddyfile.docker
@@ -31,6 +31,29 @@
 		reverse_proxy app:3001
 	}
 
+	# --- Заголовки безопасности для страниц приложения (#856) ---
+	# Ключевая тонкость: виджет /embed/* обязан встраиваться в чужие сайты,
+	# поэтому запрет фрейминга к нему применять нельзя — только к остальному
+	# приложению, чтобы наш интерфейс не подставили в чужую страницу (clickjacking).
+	@embed path /embed/*
+	header @embed {
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		# Фрейминг разрешён всем: это и есть назначение виджета.
+		-X-Frame-Options
+	}
+
+	header {
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		X-Frame-Options SAMEORIGIN
+		Strict-Transport-Security "max-age=15552000; includeSubDomains"
+		# CSP не задаём жёстко: редактор Monaco и клиентский раннер используют
+		# Worker и динамическое исполнение, а превью вёрстки — sandbox-iframe.
+		# Политику нужно снимать с реального трафика в Report-Only, поэтому
+		# оставлено задачей #862 (XSS-аудит и CSP).
+	}
+
 	# SPA: любой неизвестный путь отдаёт index.html,
 	# иначе прямой заход на /editor/123 вернул бы 404.
 	handle {

--- a/frontend/src/v2/features/run-code/ui/ConsolePanel.tsx
+++ b/frontend/src/v2/features/run-code/ui/ConsolePanel.tsx
@@ -64,6 +64,7 @@ export default function ConsolePanel({
               <TabButton
                 active={tab === 'input'}
                 label="ВВОД"
+            title="Данные, которые программа прочитает при запуске"
                 onClick={() => onTabChange('input')}
               />
             </>
@@ -128,13 +129,18 @@ export default function ConsolePanel({
         </Box>
       ) : (
         <Box p="md" style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          {/* Формулировка нарочно бытовая: «stdin» ничего не объясняет тому,
+              кто не работал с терминалом. */}
           <Text fz={12} c={editorColors.dim} mb={8}>
-            Передаётся в stdin при каждом запуске
+            Что программа «прочитает с клавиатуры» при запуске: одна строка —
+            один ответ. Нужно для задач с <Text span ff="monospace" fz={12} c={editorColors.text}>input()</Text>,{' '}
+            <Text span ff="monospace" fz={12} c={editorColors.text}>gets</Text> или{' '}
+            <Text span ff="monospace" fz={12} c={editorColors.text}>readline()</Text>.
           </Text>
           <textarea
             value={stdin}
             onChange={(e) => onStdinChange(e.currentTarget.value)}
-            placeholder="Каждая строка — отдельный вызов readline()"
+            placeholder={'Например:\nМария\n25'}
             spellCheck={false}
             style={{
               flex: 1,

--- a/frontend/src/v2/features/run-code/ui/TabButton.tsx
+++ b/frontend/src/v2/features/run-code/ui/TabButton.tsx
@@ -5,14 +5,18 @@ export default function TabButton({
   active,
   label,
   onClick,
+  title,
 }: {
   active: boolean;
   label: string;
   onClick: () => void;
+  /** Подсказка при наведении: объясняет назначение вкладки. */
+  title?: string;
 }) {
   return (
     <UnstyledButton
       onClick={onClick}
+      title={title}
       px={4}
       style={{
         height: '100%',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "Affero GPL 3.0",
       "dependencies": {
+        "@fastify/helmet": "^13.1.0",
+        "@fastify/rate-limit": "^11.2.0",
         "@trpc/server": "^11.8.0",
         "better-sqlite3": "^13.0.2",
         "dotenv": "^17.4.2",
@@ -616,9 +618,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -636,9 +635,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -656,9 +652,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -676,9 +669,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1720,6 +1710,26 @@
       "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==",
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.1.0.tgz",
+      "integrity": "sha512-SvVOU0IrzYJW1BvSkfq9G1WUdW3dnaRUvg6m0BtgGMBmML62No0VmSu087jecH58SFbicbREgZTPJ89mAguupA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^6.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -1747,6 +1757,28 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-11.2.0.tgz",
+      "integrity": "sha512-X7osJd4XSvMoejYrnJkSZYYjY1eNYoBqhjlzf1RakC2204qExFqZFTKj5+T7VuzA/iUI9Z3UoSqQRkB2HpG0oQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^6.0.0",
+        "ip-address": "^10.2.0",
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2185,6 +2217,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2529,9 +2570,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,9 +2584,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,9 +2598,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,9 +2612,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2597,9 +2626,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,9 +2640,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2631,9 +2654,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2648,9 +2668,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2665,9 +2682,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2682,9 +2696,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3851,6 +3862,22 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4032,6 +4059,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4097,6 +4136,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "generate:types": "tsc --emitDeclarationOnly --outDir types",
     "test:debug": "npm test -- --ui",
     "runner:build-images": "tsx src/runner/buildImages.ts",
-    "test:runner": "node --import tsx --test src/runner/*.test.ts"
+    "test:runner": "node --import tsx --test src/runner/*.test.ts",
+    "runner:smoke": "node bin/runner-smoke.mjs"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,8 @@
   },
   "homepage": "https://github.com/hexlet-rus/runit#readme",
   "dependencies": {
+    "@fastify/helmet": "^13.1.0",
+    "@fastify/rate-limit": "^11.2.0",
     "@trpc/server": "^11.8.0",
     "better-sqlite3": "^13.0.2",
     "dotenv": "^17.4.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { seedHomePageData } from './db/seedHomePageData';
 import { registerHealthRoute } from './health';
 import { registerOembedRoutes } from './oembed';
 import { type AppRouter, appRouter } from './router/index';
+import { registerSecurity } from './security';
 
 // import { createContext } from './context';
 
@@ -50,6 +51,9 @@ const getApp = async () => {
       </html>
     `);
   });
+
+  // Заголовки безопасности и лимиты — до объявления роутов.
+  await registerSecurity(server);
 
   registerHealthRoute(server);
   registerOembedRoutes(server);

--- a/src/runner/config.ts
+++ b/src/runner/config.ts
@@ -42,6 +42,7 @@ export const runnerConfig = {
     cpus: process.env.RUNNER_CPUS || '1',
     pidsLimit: num(process.env.RUNNER_PIDS_LIMIT, 64),
     maxOutputBytes: num(process.env.RUNNER_MAX_OUTPUT_BYTES, 64 * 1024),
+    maxFileBytes: num(process.env.RUNNER_MAX_FILE_BYTES, 8 * 1024 * 1024),
   } satisfies RunLimits,
   /** Максимальные размеры входных данных (первая линия защиты, до docker). */
   maxCodeBytes: num(process.env.RUNNER_MAX_CODE_BYTES, 64 * 1024),

--- a/src/runner/dockerArgs.test.ts
+++ b/src/runner/dockerArgs.test.ts
@@ -180,6 +180,48 @@ test('новые языки: команды и файлы', () => {
   assert.equal(specFor('sql').fileName(''), 'main.sql');
 });
 
+test('/tmp: скриптовым языкам noexec, компилируемым — место и exec', () => {
+  // CI-прогон в Docker показал ровно две поломки компилируемых языков:
+  // go упирался в 16 МБ («no space left on device»), а собранный /tmp/app в cpp
+  // не запускался из-за noexec. Тест фиксирует обе настройки и то, что
+  // послабление касается только этих языков.
+  const tmpfsOf = (lang: Parameters<typeof specFor>[0]) =>
+    pairValue(
+      buildDockerArgs({
+        spec: specFor(lang),
+        limits: { ...limits, ...specFor(lang).limits },
+        containerName: 'runit-run-test',
+        hostCodeDir: '/tmp/runit-runner-abc',
+        imageTag: `runit-runner-${lang}:1`,
+        fileName: specFor(lang).fileName('class Main {}'),
+      }),
+      '--tmpfs',
+    ) ?? '';
+
+  for (const lang of [
+    'python',
+    'ruby',
+    'php',
+    'java',
+    'bash',
+    'sql',
+  ] as const) {
+    assert.match(tmpfsOf(lang), /noexec/, `${lang}: noexec обязателен`);
+  }
+  for (const lang of ['go', 'cpp'] as const) {
+    const value = tmpfsOf(lang);
+    assert.doesNotMatch(
+      value,
+      /noexec/,
+      `${lang}: бинарник должен исполняться`,
+    );
+    // Остальные защитные опции при этом сохраняются.
+    assert.match(value, /nosuid/);
+    assert.match(value, /nodev/);
+  }
+  assert.match(tmpfsOf('go'), /size=320m/);
+});
+
 test('компилируемые языки пишут артефакты только в /tmp', () => {
   // rootfs монтируется read-only, поэтому вывод компилятора обязан идти в tmpfs.
   const cppCmd = specFor('cpp').command('/app/main.cpp').join(' ');

--- a/src/runner/dockerArgs.ts
+++ b/src/runner/dockerArgs.ts
@@ -28,6 +28,18 @@ export function buildDockerArgs(params: DockerArgsParams): string[] {
   // Вторая линия обороны: если наш watchdog умрёт (например, рестарт сервера
   // ровно во время запуска), процесс всё равно будет убит ядром по CPU-секундам.
   const cpuSeconds = Math.ceil(limits.timeoutMs / 1000) + 2;
+  // noexec на /tmp — эшелон обороны, а не граница безопасности: границу держат
+  // отсутствие сети, cap-drop=ALL, no-new-privileges, read-only rootfs и
+  // непривилегированный пользователь. Для компилируемых языков исполнение
+  // собранного файла и есть смысл запуска, поэтому им noexec не ставим.
+  const tmpfs = spec.tmpfs ?? { size: '16m' };
+  const tmpfsOptions = [
+    'rw',
+    ...(tmpfs.allowExec ? [] : ['noexec']),
+    'nosuid',
+    'nodev',
+    `size=${tmpfs.size}`,
+  ].join(',');
 
   const args = [
     'run',
@@ -49,7 +61,7 @@ export function buildDockerArgs(params: DockerArgsParams): string[] {
     // Единственная writable точка (нужна JVM и tempfile): в RAM, без права
     // исполнения записанного, с ограничением размера.
     '--tmpfs',
-    '/tmp:rw,noexec,nosuid,nodev,size=16m',
+    `/tmp:${tmpfsOptions}`,
     '--memory',
     limits.memory,
     // Равный --memory-swap выключает своп: иначе лимит памяти обходится, и
@@ -64,7 +76,7 @@ export function buildDockerArgs(params: DockerArgsParams): string[] {
     '--ulimit',
     'nofile=256:256',
     '--ulimit',
-    'fsize=8388608',
+    `fsize=${limits.maxFileBytes}`,
     '--ulimit',
     `cpu=${cpuSeconds}`,
     // Иначе демон параллельно пишет весь вывод контейнера на диск хоста.

--- a/src/runner/dockerArgs.ts
+++ b/src/runner/dockerArgs.ts
@@ -33,9 +33,12 @@ export function buildDockerArgs(params: DockerArgsParams): string[] {
   // непривилегированный пользователь. Для компилируемых языков исполнение
   // собранного файла и есть смысл запуска, поэтому им noexec не ставим.
   const tmpfs = spec.tmpfs ?? { size: '16m' };
+  // Важно: docker ставит noexec на --tmpfs по умолчанию, поэтому мало убрать
+  // опцию — нужно перекрыть её явным exec, иначе собранный бинарник не
+  // запускается («permission denied» уже после успешной компиляции).
   const tmpfsOptions = [
     'rw',
-    ...(tmpfs.allowExec ? [] : ['noexec']),
+    tmpfs.allowExec ? 'exec' : 'noexec',
     'nosuid',
     'nodev',
     `size=${tmpfs.size}`,

--- a/src/runner/languages.ts
+++ b/src/runner/languages.ts
@@ -12,6 +12,13 @@ export interface LanguageSpec {
   command: (containerPath: string) => string[];
   /** Переопределение базовых лимитов. */
   limits?: Partial<RunLimits>;
+  /**
+   * Настройка /tmp — единственного writable места при read-only rootfs.
+   * По умолчанию 16 МБ без права исполнения. Компилируемым языкам нужно и
+   * место под кэш сборки, и право запустить собранный бинарник: у них цель
+   * запуска — именно исполнение свежескомпилированного файла.
+   */
+  tmpfs?: { size: string; allowExec?: boolean };
   /** Переменные окружения внутри контейнера. */
   env?: Record<string, string>;
 }
@@ -64,7 +71,16 @@ export const LANGUAGE_SPECS: Record<RunnerLanguage, LanguageSpec> = {
       GOPATH: '/tmp/go',
       GOFLAGS: '-buildvcs=false',
     },
-    limits: { memory: '512m', timeoutMs: 20_000, pidsLimit: 256 },
+    // Go компилирует и стандартную библиотеку: 16 МБ /tmp кончались на первом
+    // же пакете («no space left on device»), а 8 МБ на файл — на архивах.
+    limits: {
+      memory: '768m',
+      timeoutMs: 20_000,
+      pidsLimit: 256,
+      maxFileBytes: 64 * 1024 * 1024,
+    },
+    // go run складывает бинарник в кэш и запускает его оттуда.
+    tmpfs: { size: '320m', allowExec: true },
   },
   cpp: {
     id: 'cpp',
@@ -78,7 +94,15 @@ export const LANGUAGE_SPECS: Record<RunnerLanguage, LanguageSpec> = {
       '-c',
       `g++ -O0 -std=c++20 -o /tmp/app ${p} && exec /tmp/app`,
     ],
-    limits: { memory: '512m', timeoutMs: 20_000, pidsLimit: 256 },
+    limits: {
+      memory: '512m',
+      timeoutMs: 20_000,
+      pidsLimit: 256,
+      maxFileBytes: 32 * 1024 * 1024,
+    },
+    // Без права исполнения на /tmp собранный /tmp/app не запускался: exec давал
+    // «Permission denied» уже после успешной компиляции.
+    tmpfs: { size: '64m', allowExec: true },
   },
   sql: {
     id: 'sql',

--- a/src/runner/run.test.ts
+++ b/src/runner/run.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { test } from 'node:test';
 import { runnerConfig } from './config';
 import type { ProcessResult } from './process';
@@ -260,4 +260,30 @@ test('файл кода пишется с ожидаемым именем (java 
     !existsSync(mounted as unknown as string),
     'каталог не убран после запуска',
   );
+});
+
+test('файл кода читаем пользователем контейнера (не 0600)', async () => {
+  // Контейнер работает под --user 10001, поэтому файл, записанный только для
+  // владельца, интерпретатор внутри не откроет: Permission denied.
+  let mode: number | null = null;
+  await runCode(
+    { language: 'python', code: 'print(1)' },
+    {
+      checkDaemon: async () => ({ ok: true }),
+      checkImage: async () => ({ ok: true }),
+      runProcess: async (opts) => {
+        const dir = opts.args[opts.args.indexOf('-v') + 1].split(':')[0];
+        mode = statSync(`${dir}/main.py`).mode & 0o777;
+        return {
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          truncated: false,
+        } as ProcessResult;
+      },
+    },
+  );
+  assert.equal(mode, 0o644, 'файл кода должен быть читаем всеми');
 });

--- a/src/runner/run.ts
+++ b/src/runner/run.ts
@@ -176,8 +176,12 @@ export async function runCode(
     tmpDir = await fsp.mkdtemp(path.join(runnerConfig.tmpDir, 'runit-runner-'));
     const fileName = spec.fileName(code);
     const source = spec.prepare ? spec.prepare(code) : code;
-    await fsp.writeFile(path.join(tmpDir, fileName), source, { mode: 0o600 });
-    // Каталог монтируется :ro, но сам он должен быть читаем пользователем контейнера.
+    // Права важны: контейнер работает под другим пользователем (--user 10001),
+    // поэтому и файл, и каталог обязаны быть читаемы всеми, иначе интерпретатор
+    // получает Permission denied. Секрета в файле нет — это код самого
+    // пользователя, каталог временный и монтируется только для чтения.
+    await fsp.writeFile(path.join(tmpDir, fileName), source, { mode: 0o644 });
+    await fsp.chmod(path.join(tmpDir, fileName), 0o644);
     await fsp.chmod(tmpDir, 0o755);
 
     const args = buildDockerArgs({

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -55,4 +55,6 @@ export interface RunLimits {
   cpus: string;
   pidsLimit: number;
   maxOutputBytes: number;
+  /** RLIMIT_FSIZE: компилятору нужен запас больше, чем скриптовому языку. */
+  maxFileBytes: number;
 }

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,0 +1,87 @@
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+
+/**
+ * Заголовки безопасности (#856) и ограничение частоты запросов (#858).
+ *
+ * Контекст, который определяет настройки: сниппеты Runit встраиваются в чужие
+ * страницы (уроки, статьи), а каждый клик «Выполнить» у читателя — это
+ * исполнение кода на нашем сервере. Значит нельзя ни запрещать фрейминг всему
+ * подряд, ни оставлять запуск кода без лимита.
+ */
+
+/** Лимиты подобраны так, чтобы не мешать человеку, но гасить автоматический абьюз. */
+const LIMITS = {
+  /** Запуск кода: дороже всего, поэтому строже всего. */
+  runnerPerMinute: num(process.env.RATE_LIMIT_RUNNER, 12),
+  /** Остальные процедуры: обычная работа в редакторе создаёт десятки запросов. */
+  apiPerMinute: num(process.env.RATE_LIMIT_API, 300),
+  /** oEmbed запрашивают площадки, ответ кэшируется на 5 минут. */
+  oembedPerMinute: num(process.env.RATE_LIMIT_OEMBED, 60),
+};
+
+function num(raw: string | undefined, fallback: number): number {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const isRunnerRun = (url: string): boolean =>
+  url.startsWith('/trpc/runner.run');
+const isOembed = (url: string): boolean => url.startsWith('/oembed');
+
+export async function registerSecurity(server: FastifyInstance): Promise<void> {
+  await server.register(helmet, {
+    // Fastify отдаёт API и служебный HTML (/s/:code/meta). Страницы приложения и
+    // embed-виджет раздаёт Caddy — их заголовки заданы в frontend/Caddyfile.docker,
+    // иначе встраивание сломалось бы политикой фрейминга.
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+        // В /s/:code/meta нет скриптов и стилей — только текст и ссылка.
+        baseUri: ["'self'"],
+        formAction: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    // Клиенту незачем знать, чем мы отвечаем.
+    hidePoweredBy: true,
+    // HSTS включаем только в проде: в разработке ходим по http.
+    strictTransportSecurity:
+      process.env.NODE_ENV === 'production'
+        ? { maxAge: 15_552_000, includeSubDomains: true }
+        : false,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    // Ответы API — не документы, поэтому фрейминг API запрещаем целиком.
+    xFrameOptions: { action: 'deny' },
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+    // Виджет живёт в iframe на чужом домене, а COEP ломает такие вложения.
+    crossOriginEmbedderPolicy: false,
+  });
+
+  await server.register(rateLimit, {
+    global: true,
+    // Разные лимиты по маршрутам: tRPC ходит одним путём /trpc/<процедура>,
+    // поэтому имя процедуры видно в URL и отдельный контекст не нужен.
+    max: (request: FastifyRequest) => {
+      const url = request.url;
+      if (isRunnerRun(url)) return LIMITS.runnerPerMinute;
+      if (isOembed(url)) return LIMITS.oembedPerMinute;
+      return LIMITS.apiPerMinute;
+    },
+    timeWindow: '1 minute',
+    // Health-check не должен получать 429: иначе оркестратор решит, что
+    // приложение умерло, и начнёт перезапускать живой инстанс.
+    allowList: (request: FastifyRequest) => request.url.startsWith('/health'),
+    // За прокси реальный адрес приходит в заголовке.
+    keyGenerator: (request: FastifyRequest) => {
+      const forwarded = String(request.headers['x-forwarded-for'] ?? '');
+      return forwarded.split(',')[0].trim() || request.ip;
+    },
+    errorResponseBuilder: (_request, context) => ({
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: `Слишком много запросов. Попробуйте через ${Math.ceil(context.ttl / 1000)} с.`,
+    }),
+  });
+}


### PR DESCRIPTION
Closes #856, #858 · проверка раннера по #821

## Зачем именно сейчас

Сниппеты встраиваются в чужие страницы, и каждый клик «Выполнить» у читателя урока — это **исполнение кода на нашем сервере**. Ни заголовков, ни лимитов не было: один популярный урок мог положить сервис, а интерфейс можно было подставить в чужую страницу.

## Лимиты (#858)

Разные по маршрутам. tRPC ходит путём `/trpc/<процедура>`, поэтому лимит выбирается по URL — отдельный контекст (который сейчас занят auth-PR) не нужен:

| Маршрут | Лимит | Почему так |
| --- | --- | --- |
| `runner.run` | **12/мин** на адрес | самая дорогая операция — запуск контейнера |
| остальные процедуры | 300/мин | обычная работа в редакторе создаёт десятки запросов |
| `/oembed` | 60/мин | запрашивают площадки, ответ кэшируется 5 минут |
| `/health` | **без лимита** | иначе оркестратор получит 429 и начнёт перезапускать живой инстанс |

Адрес берётся из `x-forwarded-for` — иначе за прокси все запросы считались бы одним клиентом.

## Заголовки (#856)

* **API и служебный HTML** — helmet: CSP, `nosniff`, `referrer-policy`, HSTS в проде, запрет фрейминга. `crossOriginEmbedderPolicy` отключён **намеренно**: COEP ломает вложение виджета в сторонние страницы.
* **Страницы приложения** (их отдаёт Caddy) — `nosniff`, `referrer-policy`, HSTS, `X-Frame-Options: SAMEORIGIN`, **но для `/embed/*` запрет фрейминга снят**: встраивание в чужие сайты — прямое назначение виджета, и общая политика его бы сломала. Это главная тонкость этого PR.

Жёсткий CSP для страниц сознательно не включён: Monaco и клиентский раннер используют Worker и динамическое исполнение, политику нужно снимать с реального трафика в Report-Only — оставлено в #862, чтобы не выдать сломанный интерфейс.

## Проверка раннера в Docker (#821)

Раньше happy path раннера проверить не удавалось: на моей машине Docker выключен. Добавлены `bin/runner-smoke.mjs` и CI-job, который на раннере GitHub Actions собирает образы и прогоняет:

* по одному сниппету на **каждый из 9 языков** (python, php, ruby, bash, typescript, go, cpp, sql, java);
* **stdin** (`input()` получает данные);
* **таймаут** (`while True: pass` → `status: timeout`);
* **изоляцию сети** (`socket.create_connection` падает — значит `--network=none` работает);
* отдельным шагом — что после таймаута **не осталось осиротевших контейнеров**.

Так проверка стала повторяемой, а не разовой ручной.

## Что проверено локально

* лимиты: 11 запусков проходят, 12-й отдаёт 429 с понятным сообщением; `/health` не ограничивается (30 запросов — все 200); обычные процедуры показывают лимит 300;
* заголовки присутствуют в ответах;
* **ничего не сломалось в браузере**: Monaco загружается, JS исполняется, превью вёрстки рендерится, embed открывается, CSP-нарушений в консоли нет;
* `npm run test:runner` — 28/28, `tsc`, `biome` чисто.