### PR TITLE
Фронт: шторм автосохранения, двойной Ctrl+Enter, сортировка по битым датам (#875, #879, #881)

### DIFF
--- a/frontend/src/v2/features/manage-snippets/model/useSnippetFilter.ts
+++ b/frontend/src/v2/features/manage-snippets/model/useSnippetFilter.ts
@@ -3,7 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useSession } from '../../../entities/user';
 import { useTRPCClient } from '../../../shared/api';
-import { SNIPPETS_QUERY_KEY, getMySnippets } from '../../../entities/snippet';
+import {
+  SNIPPETS_QUERY_KEY,
+  getMySnippets,
+  type Snippet,
+} from '../../../entities/snippet';
 import { parseTimestamp } from '../../../shared/lib/dates';
 
 type SortMode = 'new' | 'old' | 'name';
@@ -39,14 +43,35 @@ export default function useSnippetFilter() {
       if (query && !s.name.toLowerCase().includes(query)) return false;
       return true;
     });
+    /**
+     * Порядок при равных ключах задаётся явно — по имени, затем по id (#881).
+     * Без этого сниппеты с одинаковой датой (а секунда вмещает несколько
+     * созданий) выстраивались как придётся, и список подрагивал при каждом
+     * перезапросе.
+     */
+    const byNameThenId = (a: Snippet, b: Snippet) =>
+      a.name.localeCompare(b.name, 'ru') || a.id - b.id;
+
     const sorted = [...filtered];
     if (sort === 'name') {
-      sorted.sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+      sorted.sort(byNameThenId);
     } else {
       sorted.sort((a, b) => {
         const da = parseTimestamp(a.createdAt);
         const db = parseTimestamp(b.createdAt);
-        return sort === 'new' ? db - da : da - db;
+
+        /**
+         * Записи без читаемой даты всегда в конце — в обоих направлениях.
+         * Прежде отсутствующая дата превращалась в 1970 год, и при сортировке
+         * «сначала старые» битые записи всплывали на самый верх, будто они
+         * самые ранние. Неизвестная дата — это отсутствие сведений, а не
+         * древность.
+         */
+        if (da === null && db === null) return byNameThenId(a, b);
+        if (da === null) return 1;
+        if (db === null) return -1;
+
+        return (sort === 'new' ? db - da : da - db) || byNameThenId(a, b);
       });
     }
     return sorted;

--- a/frontend/src/v2/features/run-code/model/useRunner.ts
+++ b/frontend/src/v2/features/run-code/model/useRunner.ts
@@ -12,7 +12,9 @@ import { type OutputTab } from '..';
 /**
  * Хук управления запуском кода и состоянием консоли.
  *
- * Регистрирует глобальный хоткей Ctrl+Enter (дублируется Monaco-командой из EditorPage).
+ * Регистрирует глобальный хоткей Ctrl+Enter. Внутри редактора кода работает
+ * команда Monaco (EditorPage), здесь такие события пропускаются — иначе одно
+ * нажатие давало бы два запуска (#879).
  *  
  * @param code — текущий код в редакторе
  * @param language — текущий язык
@@ -81,12 +83,30 @@ export default function useRunner(code: string, language: string) {
   const runRef = useRef(handleRun);
   runRef.current = handleRun;
 
+  /**
+   * Глобальный Ctrl/Cmd+Enter (#879).
+   *
+   * Внутри редактора кода хоткей не обрабатывается: там своя команда Monaco
+   * (см. EditorPage). Раньше срабатывали оба, и одно нажатие давало два запуска
+   * — на сервере это два контейнера и два ответа в консоли, а для превью
+   * вёрстки двойная перерисовка.
+   *
+   * В однострочных полях (название сниппета, поиск) хоткей тоже не работает:
+   * там Enter принадлежит форме, и запуск кода по нему — неожиданность. В
+   * многострочном поле ввода stdin, наоборот, оставлен: набрать данные и
+   * запустить не отрывая рук — обычный сценарий.
+   */
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-        e.preventDefault();
-        void runRef.current();
-      }
+      if (!(e.ctrlKey || e.metaKey) || e.key !== 'Enter') return;
+
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('.monaco-editor')) return;
+      if (target instanceof HTMLInputElement) return;
+      if (target?.isContentEditable) return;
+
+      e.preventDefault();
+      void runRef.current();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);

--- a/frontend/src/v2/pages/editor/model/useSnippetSave.ts
+++ b/frontend/src/v2/pages/editor/model/useSnippetSave.ts
@@ -31,13 +31,46 @@ export default function useSnippetSave(
   const snippetIdRef = useRef(snippetId);
   snippetIdRef.current = snippetId;
 
-  /** Сохраняет сниппет (создаёт или обновляет) через API. */
-  const saveNow = useCallback(async () => {
+  /**
+   * Состояние неудачных попыток автосохранения (#875).
+   *
+   * Автосохранение запускалось по факту «статус = unsaved», а неудачная попытка
+   * возвращала ровно этот статус — получался цикл: каждые 1,5 секунды новый
+   * запрос и новый тост «Не удалось сохранить». При недоступном сервере это
+   * бесконечный поток запросов и заваленный тостами экран.
+   *
+   * Теперь: пауза между попытками растёт (1,5 → 3 → 6 → 12 с), попыток не
+   * больше четырёх, тост показывается один раз на серию, а не на каждую
+   * попытку. Правка кода или нажатие «Сохранить» сбрасывают счётчик — значит
+   * восстановившийся сервер подхватится с первого же изменения.
+   */
+  const AUTOSAVE_BASE_DELAY_MS = 1500;
+  const AUTOSAVE_MAX_ATTEMPTS = 4;
+  const failedAttemptsRef = useRef(0);
+  const notifiedRef = useRef(false);
+  const [autosaveDelay, setAutosaveDelay] = useState(AUTOSAVE_BASE_DELAY_MS);
+
+  const resetFailures = useCallback(() => {
+    failedAttemptsRef.current = 0;
+    notifiedRef.current = false;
+    setAutosaveDelay(AUTOSAVE_BASE_DELAY_MS);
+  }, []);
+
+  /**
+   * Сохраняет сниппет (создаёт или обновляет) через API.
+   *
+   * `manual` — вызов кнопкой «Сохранить». Такой вызов означает «попробуй сейчас»:
+   * счётчик неудач сбрасывается, поэтому попытка происходит даже после серии
+   * сбоев, и об очередной неудаче пользователю снова сообщают — он ведь только
+   * что нажал кнопку и ждёт ответа.
+   */
+  const saveNow = useCallback(async (manual = false) => {
     if (isGuest || !user) {
       auth.open('register');
       return;
     }
     if (savingRef.current) return;
+    if (manual) resetFailures();
     savingRef.current = true;
     setSaveStatus('saving');
     try {
@@ -59,32 +92,82 @@ export default function useSnippetSave(
         });
         setSaveStatus('saved');
       }
+      resetFailures();
     } catch {
+      failedAttemptsRef.current += 1;
+      // Пауза удваивается: сервер, который лежит, не нужно опрашивать каждые
+      // 1,5 секунды.
+      setAutosaveDelay(
+        AUTOSAVE_BASE_DELAY_MS * 2 ** (failedAttemptsRef.current - 1),
+      );
       setSaveStatus('unsaved');
-      notifications.show({
-        message: 'Не удалось сохранить сниппет',
-        color: 'red',
-      });
+
+      if (!notifiedRef.current) {
+        notifiedRef.current = true;
+        notifications.show({
+          message:
+            'Не удалось сохранить сниппет. Проверьте соединение — попробуем ещё раз автоматически.',
+          color: 'red',
+        });
+      }
     } finally {
       savingRef.current = false;
     }
-  }, [isGuest, user, auth, trpc, navigate, nameRef, codeRef, languageRef]);
+  }, [
+    isGuest,
+    user,
+    auth,
+    trpc,
+    navigate,
+    nameRef,
+    codeRef,
+    languageRef,
+    resetFailures,
+  ]);
 
-  // Автосохранение с debounce 1.5 c — только для сохранённого сниппета юзера.
+  /**
+   * Автосохранение сохранённого сниппета. Пауза растёт после каждой неудачи,
+   * а после AUTOSAVE_MAX_ATTEMPTS попыток автосохранение останавливается: дальше
+   * либо пользователь правит код (сброс счётчика), либо нажимает «Сохранить».
+   */
   useEffect(() => {
     if (saveStatus !== 'unsaved') return;
     if (isGuest || snippetId == null) return;
+    if (failedAttemptsRef.current >= AUTOSAVE_MAX_ATTEMPTS) return;
+
     const timer = setTimeout(() => {
       void saveNow();
-    }, 1500);
+    }, autosaveDelay);
     return () => clearTimeout(timer);
-  }, [saveStatus, nameRef, codeRef, languageRef, isGuest, snippetId, saveNow]);
+  }, [
+    saveStatus,
+    autosaveDelay,
+    nameRef,
+    codeRef,
+    languageRef,
+    isGuest,
+    snippetId,
+    saveNow,
+  ]);
 
-  /** Помечает сниппет как несохранённый — триггерит автосохранение через 1.5 с. */
-  const markDirty = useCallback(() => setSaveStatus('unsaved'), []);
+  /**
+   * Помечает сниппет как несохранённый — запускает автосохранение.
+   * Правка означает новую попытку: счётчик неудач и пауза сбрасываются, иначе
+   * после серии сбоев редактор перестал бы сохранять до перезагрузки страницы.
+   */
+  const markDirty = useCallback(() => {
+    resetFailures();
+    setSaveStatus('unsaved');
+  }, [resetFailures]);
+
+  /** Обёртка для кнопки «Сохранить»: явное действие пользователя. */
+  const saveManually = useCallback(() => {
+    void saveNow(true);
+  }, [saveNow]);
 
   return {
     saveNow,
+    saveManually,
     markDirty,
     saveStatus,
     setSaveStatus,

--- a/frontend/src/v2/pages/editor/ui/EditorHeader.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorHeader.tsx
@@ -67,7 +67,18 @@ export default function EditorHeader( props: EditorHeaderProps ) {
         borderBottom: '1px solid #e9ecef',
       }}
     >
-      <Group gap="sm" wrap="nowrap" style={{ minWidth: 0 }}>
+      {/*
+        Левая часть сжимается и обрезается, правая — нет. Без этого на узком
+        экране (примерно от 900 px) имя сниппета и статус сохранения заезжали
+        на кнопки «Поделиться» и «Выполнить»: у Group стоит wrap="nowrap", а
+        input имел фиксированную ширину, поэтому лишнее не убиралось, а
+        накладывалось поверх.
+      */}
+      <Group
+        gap="sm"
+        wrap="nowrap"
+        style={{ minWidth: 0, flex: '1 1 auto', overflow: 'hidden' }}
+      >
           <Tooltip label="К моим сниппетам" withArrow>
             <ActionIcon
               component={Link}
@@ -99,8 +110,9 @@ export default function EditorHeader( props: EditorHeaderProps ) {
               fontSize: 15,
               fontWeight: 600,
               color: '#212529',
-              width: 200,
-              minWidth: 0,
+              flex: '0 1 200px',
+              minWidth: 60,
+              textOverflow: 'ellipsis',
             }}
           />
           <Group
@@ -123,7 +135,9 @@ export default function EditorHeader( props: EditorHeaderProps ) {
             }
             withArrow
           >
-            <UnstyledButton onClick={() => void saveNow()}>
+            {/* Статус сохранения не сжимается и не обрезается: это обратная
+                связь о сохранности работы, она важнее длины имени. */}
+            <UnstyledButton onClick={() => void saveNow()} style={{ flexShrink: 0 }}>
               <Group gap={6} wrap="nowrap">
                 <Box
                   w={8}
@@ -138,10 +152,16 @@ export default function EditorHeader( props: EditorHeaderProps ) {
           </Tooltip>
         </Group>
 
-        <Group gap="sm" wrap="nowrap">
-          {/* TODO(#836, #837): история версий со снапшотами и diff */}
+        <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
+          {/*
+            Обе кнопки — заглушки нереализованных функций, и обе скрыты на
+            узких экранах: места в шапке не хватает, а из-за них статус
+            сохранения оказывался перекрыт. Работающие элементы приоритетнее
+            неработающих.
+          */}
           <Tooltip label="В разработке (#836/#837)" withArrow>
             <ActionIcon
+              visibleFrom="md"
               variant="subtle"
               color="gray"
               data-disabled
@@ -154,6 +174,7 @@ export default function EditorHeader( props: EditorHeaderProps ) {
           {/* TODO(#3, #838): совместное редактирование в реальном времени */}
           <Tooltip label="В разработке (#3/#838)" withArrow>
             <ActionIcon
+              visibleFrom="md"
               variant="subtle"
               color="gray"
               data-disabled

--- a/frontend/src/v2/pages/editor/ui/EditorPage.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorPage.tsx
@@ -64,7 +64,7 @@ export default function EditorPage() {
     clearLines,
   } = useRunner(code, language);
   const {
-    saveNow,
+    saveManually,
     markDirty,
     saveStatus,
     setSaveStatus,
@@ -186,7 +186,7 @@ export default function EditorPage() {
         setName={setName}
         name={name}
         meta={meta}
-        saveNow={saveNow}
+        saveNow={saveManually}
         statusMeta={statusMeta}
         setShareOpened={setShareOpened}
         handleRun={handleRun}

--- a/frontend/src/v2/shared/api/refreshOnExpiry.ts
+++ b/frontend/src/v2/shared/api/refreshOnExpiry.ts
@@ -57,12 +57,23 @@ const refreshOnce = (): Promise<boolean> => {
   return inFlight;
 };
 
-/** Не пытаемся продлевать сессию на самих auth-запросах — получилась бы петля. */
+/**
+ * Запросы, для которых продление не делается.
+ *
+ * `auth.refresh` — иначе петля. `auth.login` и `auth.register` — там сессии ещё
+ * нет, продлевать нечего.
+ *
+ * `auth.me` в этом списке быть НЕ должен, хотя выглядит похоже. Именно им
+ * приложение восстанавливает сессию при загрузке страницы: если access-токен
+ * истёк (15 минут), а refresh жив (30 дней), то без продления `me` отвечает 401
+ * и интерфейс показывает гостя — пользователь оказывался «разлогинен» после
+ * любой паузы в работе, хотя его сессия действительна ещё месяц. Это и было
+ * видно в проверке: сессия слетала сама.
+ */
 const isAuthCall = (url: string): boolean =>
   url.includes('/trpc/auth.refresh') ||
   url.includes('/trpc/auth.login') ||
-  url.includes('/trpc/auth.register') ||
-  url.includes('/trpc/auth.me');
+  url.includes('/trpc/auth.register');
 
 export const fetchWithRefresh: typeof fetch = async (input, init) => {
   const request = () =>

--- a/frontend/src/v2/shared/lib/dates.ts
+++ b/frontend/src/v2/shared/lib/dates.ts
@@ -39,8 +39,21 @@ export function relativeDate(input: string | Date | null | undefined): string {
   return years === 1 ? 'год назад' : `${years} ${plural(years, ['год', 'года', 'лет'])} назад`;
 }
 
-/** Приводит строку с датой к числовому таймстампу. Если дата некорректна или отсутствует — возвращает 0. */
-export const parseTimestamp = (d: string | null | undefined): number => {
+/**
+ * Таймстамп из даты или null, если даты нет или она нечитаема (#881).
+ *
+ * Раньше функция возвращала 0 — то есть 1 января 1970 года. Отсутствующая дата
+ * становилась не «неизвестно», а «самая старая запись», и при сортировке
+ * «сначала старые» такие сниппеты оказывались наверху списка.
+ *
+ * Отдельная тонкость: `new Date(null)` — это не NaN, а начало эпохи, поэтому
+ * прежняя проверка на NaN пропускала null молча. Здесь null отсекается до
+ * разбора.
+ */
+export const parseTimestamp = (
+  d: string | Date | null | undefined,
+): number | null => {
+  if (d === null || d === undefined || d === '') return null;
   const t = new Date(d).getTime();
-  return Number.isNaN(t) ? 0 : t;
+  return Number.isNaN(t) ? null : t;
 };


### PR DESCRIPTION
Три открытых бага фронта плюс два дефекта, найденных при проверке вёрстки.

## #875 — шторм автосохранения

Автосохранение запускалось по факту «статус = unsaved», а неудачная попытка возвращала **ровно этот статус** — цикл: каждые 1,5 с новый запрос и новый тост. При недоступном сервере это бесконечный поток запросов и заваленный тостами экран.

Теперь пауза растёт (1,5 → 3 → 6 → 12 с), попыток не больше четырёх, тост один на серию. Правка кода сбрасывает счётчик — восстановившийся сервер подхватится с первого изменения. Кнопка «Сохранить» всегда пробует заново и сообщает о результате.

Проверено с оборванной сетью: в логах видно попытки 1→2→3 с растущими паузами и **один** тост; статус в шапке — «Не сохранено».

## #879 — двойной запуск по Ctrl+Enter

Хоткей обрабатывался дважды: командой Monaco и глобальным слушателем окна. Одно нажатие — два запуска, на сервере это два контейнера и два ответа в консоли.

Внутри редактора кода глобальный обработчик теперь пропускает событие. В однострочных полях (имя, поиск) хоткей не срабатывает — там Enter принадлежит форме. В `textarea` для stdin оставлен: набрать данные и запустить не отрывая рук.

Проверено: событие вне полей → 1 запуск, внутри Monaco → 0 (работает команда Monaco), в `input` → 0.

## #881 — сортировка по битым датам

Отсутствующая дата превращалась в `0`, то есть в 1970 год: при сортировке «сначала старые» записи без даты всплывали наверх, будто они самые ранние. Тонкость: `new Date(null)` — не `NaN`, а начало эпохи, поэтому прежняя проверка пропускала `null` молча.

Теперь нечитаемая дата — это `null`, такие записи всегда в конце в обоих направлениях, а при равных датах порядок задаётся явно (имя, затем id) — иначе список подрагивал при каждом перезапросе. Проверено: `null`, `undefined`, `''`, мусор → `null`; корректная ISO-дата → число.

## #628 — продление сессии не работало на `auth.me`

Найдено при проверке: я сам исключил `auth.me` из продления, а это ровно тот запрос, которым приложение восстанавливает сессию при загрузке. С истёкшим access-токеном (15 минут) страница показывала гостя, хотя refresh живёт 30 дней — сессия «слетала» после любой паузы в работе.

Проверено с укороченным до 3 секунд токеном: перезагрузка `/snippets` возвращает дашборд со сниппетами, а не лендинг.

## Вёрстка шапки редактора

Левая часть не сжималась (`wrap="nowrap"` и фиксированная ширина имени), поэтому примерно от 900 px имя и статус сохранения **заезжали** на кнопки «Поделиться» и «Выполнить». Теперь левая часть сжимается и обрезается, правая — нет; статус не обрезается (это обратная связь о сохранности работы), а две кнопки-заглушки нереализованных функций скрыты на узких экранах.

Проверено попарным тестом на перекрытия: на 1280 и 768 перекрытий нет, статус виден, кнопки на месте.

## Обход вёрстки по разрешениям

Проверил 375, 768 и 1280 на страницах: лендинг, дашборд, редактор, страница шаринга, встраиваемый виджет, демо встраивания, публичный профиль, настройки, три вкладки правовых документов, 404.

Горизонтального переполнения нет нигде. Публичные страницы, дашборд и настройки корректно перестраиваются на 375.

**Остаётся сломанным редактор на мобильной ширине**: три панели (файлы, код, консоль) стоят рядом, поэтому на 375 код не виден вовсе, а статус-строка расползается. Это #842 — отдельная задача, здесь не решается: нужен режим с переключением панелей, а не подгонка отступов.
