### PR TITLE
Редактор: мобильный режим с переключением панелей (#842)

### DIFF
--- a/frontend/src/v2/pages/editor/ui/EditorHeader.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorHeader.tsx
@@ -90,7 +90,9 @@ export default function EditorHeader( props: EditorHeaderProps ) {
               <IconArrowLeft />
             </ActionIcon>
           </Tooltip>
-          <UnstyledButton component={Link} to="/">
+          {/* Логотип на мобильном лишний: рядом есть стрелка «назад», а
+              ширины в шапке не хватает (#842). */}
+          <UnstyledButton component={Link} to="/" visibleFrom="sm">
             <RunitLogo size={26} />
           </UnstyledButton>
           <input
@@ -115,11 +117,13 @@ export default function EditorHeader( props: EditorHeaderProps ) {
               textOverflow: 'ellipsis',
             }}
           />
+          {/* Язык на мобильном показан в статус-баре — здесь не дублируем. */}
           <Group
             gap={6}
             px={10}
             py={4}
             wrap="nowrap"
+            visibleFrom="sm"
             style={{ background: '#f1f3f5', borderRadius: 8, flexShrink: 0 }}
           >
             <Box w={8} h={8} style={{ borderRadius: '50%', background: meta.dot }} />
@@ -144,7 +148,12 @@ export default function EditorHeader( props: EditorHeaderProps ) {
                   h={8}
                   style={{ borderRadius: '50%', background: statusMeta.color }}
                 />
-                <Text fz="sm" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                <Text
+                  fz="sm"
+                  c="dimmed"
+                  visibleFrom="sm"
+                  style={{ whiteSpace: 'nowrap' }}
+                >
                   {statusMeta.label}
                 </Text>
               </Group>
@@ -185,12 +194,23 @@ export default function EditorHeader( props: EditorHeaderProps ) {
             </ActionIcon>
           </Tooltip>
           <Button
+            visibleFrom="sm"
             variant="light"
             leftSection={<IconShare />}
             onClick={() => setShareOpened(true)}
           >
             Поделиться
           </Button>
+          {/* На мобильном подпись не помещается, действие остаётся доступным. */}
+          <ActionIcon
+            hiddenFrom="sm"
+            variant="light"
+            size="lg"
+            aria-label="Поделиться"
+            onClick={() => setShareOpened(true)}
+          >
+            <IconShare />
+          </ActionIcon>
           <Tooltip label="Ctrl + Enter" withArrow>
             <Button
               leftSection={<IconPlay />}

--- a/frontend/src/v2/pages/editor/ui/EditorPage.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorPage.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router';
-import { Box, Button, Center, Loader, Stack, Text } from '@mantine/core';
+import {
+  Box,
+  Button,
+  Center,
+  Loader,
+  SegmentedControl,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
 import MonacoEditor, { type OnMount } from '@monaco-editor/react';
 
@@ -9,6 +18,7 @@ import { editorColors, langMeta, runtimeLabel } from '../../../shared/theme';
 import { useSession } from '../../../entities/user';
 
 import { ConsolePanel } from '../../../features/run-code';
+import { isPreviewLanguage } from '../../../shared/runner/preview';
 import { ShareModal } from '../../../features/share-snippet';
 import AddPackageModal from './AddPackageModal';
 
@@ -43,6 +53,20 @@ export default function EditorPage() {
   const [shareOpened, setShareOpened] = useState(false);
   const [packageOpened, setPackageOpened] = useState(false);
 
+  /**
+   * Мобильная раскладка (#842).
+   *
+   * На узком экране три панели рядом не помещаются: при 375 px код не виден
+   * вовсе — его выдавливают сайдбар файлов и консоль. Поэтому панели не
+   * сжимаются, а переключаются, а сайдбар скрыт: мультифайловость ещё не
+   * реализована (#818/#819), файл всегда один, и на мобильном это 212 px
+   * бесполезной ширины.
+   *
+   * Порог 768 px — та же граница, что у остальных адаптивных правил интерфейса.
+   */
+  const isMobile = useMediaQuery('(max-width: 767px)') ?? false;
+  const [mobilePane, setMobilePane] = useState<'code' | 'output'>('code');
+
   // Рефы для стабильных колбэков (saveNow использует их через useSnippetSave).
   const nameRef = useRef(name);
   const codeRef = useRef(code);
@@ -63,6 +87,17 @@ export default function EditorPage() {
     handleRun,
     clearLines,
   } = useRunner(code, language);
+
+  /**
+   * На мобильном при запуске сразу показываем вывод: иначе пользователь нажимает
+   * «Выполнить» и остаётся на панели кода, где ничего не происходит.
+   *
+   * Слежение за состоянием, а не обёртка вокруг кнопки: запуск бывает и с
+   * хоткея, и из превью вёрстки (там running не поднимается, меняется runKey).
+   */
+  useEffect(() => {
+    if (isMobile && (running || runKey > 0)) setMobilePane('output');
+  }, [isMobile, running, runKey]);
   const {
     saveManually,
     markDirty,
@@ -195,21 +230,40 @@ export default function EditorPage() {
       />
 
       {/* ===== Основная область ===== */}
+      {isMobile && (
+        /*
+          Переключатель панелей вместо трёх колонок. Панели остаются
+          смонтированными (скрываются через display), иначе Monaco теряет
+          историю правок и позицию курсора при каждом переключении.
+        */
+        <SegmentedControl
+          fullWidth
+          radius={0}
+          value={mobilePane}
+          onChange={(value) => setMobilePane(value as 'code' | 'output')}
+          data={[
+            { value: 'code', label: 'Код' },
+            { value: 'output', label: isPreviewLanguage(language) ? 'Превью' : 'Консоль' },
+          ]}
+        />
+      )}
       <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
         {/* --- Левый сайдбар (212px) --- */}
-        <EditorSidebar
-          fileName={fileName}
-          meta={meta}
-          language={language}
-          setPackageOpened={setPackageOpened}
-        />
+        {!isMobile && (
+          <EditorSidebar
+            fileName={fileName}
+            meta={meta}
+            language={language}
+            setPackageOpened={setPackageOpened}
+          />
+        )}
 
         {/* --- Центр: редактор кода --- */}
         <div
           style={{
             flex: 1,
             minWidth: 0,
-            display: 'flex',
+            display: isMobile && mobilePane !== 'code' ? 'none' : 'flex',
             flexDirection: 'column',
             background: editorColors.bg,
           }}
@@ -263,8 +317,14 @@ export default function EditorPage() {
           </div>
         </div>
 
-        {/* --- Правая панель: консоль/ввод (~25%) --- */}
-        <div style={{ width: '25%', flexShrink: 0, minWidth: 260 }}>
+        {/* --- Правая панель: консоль/ввод (~25%, на мобильном — во всю ширину) --- */}
+        <div
+          style={
+            isMobile
+              ? { flex: 1, minWidth: 0, display: mobilePane === 'output' ? 'block' : 'none' }
+              : { width: '25%', flexShrink: 0, minWidth: 260 }
+          }
+        >
           <ConsolePanel
             tab={tab}
             onTabChange={setTab}
@@ -282,7 +342,12 @@ export default function EditorPage() {
       </div>
 
       {/* ===== Статус-бар (28px) ===== */}
-      <EditorStatusBar meta={meta} language={language} cursor={cursor} />
+      <EditorStatusBar
+        meta={meta}
+        language={language}
+        cursor={cursor}
+        compact={isMobile}
+      />
 
       <ShareModal
         opened={shareOpened}

--- a/frontend/src/v2/pages/editor/ui/EditorStatusBar.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorStatusBar.tsx
@@ -12,10 +12,42 @@ export type StatusBarProps = {
     line: number;
     col: number;
   },
+  /**
+   * Короткий вид для мобильного (#842). На 375 px все шесть подписей не
+   * помещаются в строку 28 px и расползаются в две-три строки, ломая раскладку.
+   * Остаются язык и позиция курсора — единственное, что меняется по ходу работы;
+   * остальное (кодировка, версия, размер отступа) постоянно и на маленьком
+   * экране только занимает место.
+   */
+  compact?: boolean,
 }
 
 export default function EditorStatusBar(props: StatusBarProps) {
-  const { meta, language, cursor } = props;
+  const { meta, language, cursor, compact = false } = props;
+
+  if (compact) {
+    return (
+      <Group
+        px="sm"
+        justify="space-between"
+        wrap="nowrap"
+        style={{
+          height: 28,
+          flexShrink: 0,
+          background: '#fff',
+          borderTop: '1px solid #e9ecef',
+        }}
+      >
+        <Text fz={12} c="dimmed" truncate>
+          {meta.label}
+        </Text>
+        <Text fz={12} c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+          {cursor.line}:{cursor.col}
+        </Text>
+      </Group>
+    );
+  }
+
   return (
     <Group
       px="md"


### PR DESCRIPTION
На узком экране редактор был неработоспособен: три панели (файлы, код, консоль) стояли рядом, и при 375 px **код не был виден вовсе** — его выдавливали сайдбар и консоль, а статус-строка из шести подписей расползалась в кашу. Подгонкой отступов это не лечится, нужен другой режим.

## Что сделано на ширине до 768 px

- **Панели переключаются** сегментированным контролом «Код | Консоль» (для вёрстки — «Превью») и занимают всю ширину. Обе остаются смонтированными и скрываются через `display`: иначе Monaco при каждом переключении терял бы историю правок и позицию курсора.
- **Сайдбар файлов скрыт.** Мультифайловость не реализована (#818/#819), файл всегда один — на мобильном это 212 px бесполезной ширины.
- **При запуске панель вывода показывается сама.** Иначе пользователь нажимает «Выполнить» и остаётся на панели кода, где ничего не происходит. Следим за состоянием запуска, а не оборачиваем кнопку: запуск бывает и с хоткея, и из превью вёрстки (там `running` не поднимается, меняется `runKey`).
- **Статус-строка сокращена** до языка и позиции курсора — единственного, что меняется по ходу работы. Кодировка, версия и размер отступа постоянны и на маленьком экране только занимают место.
- **Из шапки убрано дублирующее**: логотип (рядом стрелка «назад»), плашка языка (язык есть в статус-строке), подпись статуса (осталась цветная точка), «Поделиться» стало иконкой. Без этого шапка не помещалась в 375 px и уезжала за край.

На ширине от 768 px раскладка не изменилась: сайдбар, код и консоль рядом, полная статус-строка, все подписи в шапке.

## Проверка

В браузере на 375 и 1280:

- горизонтального переполнения нет ни на одной ширине;
- переключение панелей работает, код виден во всю ширину;
- «Выполнить» показывает вывод: `Процесс завершён`, активная панель — `output`;
- поле stdin (вкладка ВВОД) доступно во всю ширину;
- на 1280 переключателя нет, сайдбар и консоль на месте, статус-строка полная.

Closes #842
