### PR TITLE
Лендинг: HTML и CSS в списке технологий

### DIFF
--- a/frontend/src/v2/pages/landing/ui/Languages.tsx
+++ b/frontend/src/v2/pages/landing/ui/Languages.tsx
@@ -1,10 +1,19 @@
 import { Box, Group, Text, Title } from '@mantine/core';
 import { langMeta } from '../../../shared/theme';
 
-// Чипы «10 языков — из коробки». В MVP реально исполняется только JavaScript,
-// остальные чипы — просто витрина (это ок по макету).
-// TODO(#843): когда появится серверное исполнение (#821), пометить runnable-языки.
-const LANGS: { label: string; dot: string }[] = [
+/**
+ * Чипы языков на лендинге.
+ *
+ * Список совпадает с тем, что редактор действительно умеет: девять языков
+ * исполняются на сервере в docker-контейнере, JavaScript — в браузере, а HTML и
+ * CSS показываются превью. Раньше здесь было десять чипов и оговорка «реально
+ * исполняется только JavaScript» — она устарела, серверный раннер работает и
+ * проверяется смоуком в CI на каждом PR.
+ *
+ * Разметка выделена отдельной группой: обещать «исполнение» HTML и CSS
+ * неправильно — их не запускают, а отображают.
+ */
+const CODE_LANGS: { label: string; dot: string }[] = [
   { label: 'JavaScript', dot: langMeta.javascript.dot },
   { label: 'TypeScript', dot: langMeta.typescript.dot },
   { label: 'Python', dot: langMeta.python.dot },
@@ -17,33 +26,51 @@ const LANGS: { label: string; dot: string }[] = [
   { label: 'Bash', dot: '#89e051' },
 ];
 
+const MARKUP_LANGS: { label: string; dot: string }[] = [
+  { label: 'HTML', dot: langMeta.html.dot },
+  { label: 'CSS', dot: langMeta.css.dot },
+];
+
+function Chip({ label, dot }: { label: string; dot: string }) {
+  return (
+    <Group
+      gap={8}
+      px={16}
+      py={8}
+      style={{
+        border: '1px solid #e9ecef',
+        borderRadius: 999,
+        background: '#fff',
+      }}
+    >
+      <Box w={8} h={8} style={{ borderRadius: '50%', background: dot }} />
+      <Text fz="sm" fw={500}>
+        {label}
+      </Text>
+    </Group>
+  );
+}
+
 export default function Languages() {
   return (
     <Box ta="center">
       <Title order={2} fz={{ base: 26, sm: 32 }} mb="xs">
-        10 языков — из коробки
+        12 языков — из коробки
       </Title>
       <Text c="dimmed" mb="xl">
         Выбирайте язык при создании сниппета — окружение уже настроено.
       </Text>
       <Group justify="center" gap="sm">
-        {LANGS.map((lang) => (
-          <Group
-            key={lang.label}
-            gap={8}
-            px={16}
-            py={8}
-            style={{
-              border: '1px solid #e9ecef',
-              borderRadius: 999,
-              background: '#fff',
-            }}
-          >
-            <Box w={8} h={8} style={{ borderRadius: '50%', background: lang.dot }} />
-            <Text fz="sm" fw={500}>
-              {lang.label}
-            </Text>
-          </Group>
+        {CODE_LANGS.map((lang) => (
+          <Chip key={lang.label} label={lang.label} dot={lang.dot} />
+        ))}
+      </Group>
+      <Text c="dimmed" fz="sm" mt="xl" mb="sm">
+        А вёрстку видно сразу — HTML и CSS открываются в превью:
+      </Text>
+      <Group justify="center" gap="sm">
+        {MARKUP_LANGS.map((lang) => (
+          <Chip key={lang.label} label={lang.label} dot={lang.dot} />
         ))}
       </Group>
     </Box>


### PR DESCRIPTION
На лендинге было десять чипов, хотя редактор поддерживает двенадцать: девять языков исполняются на сервере, JavaScript — в браузере, HTML и CSS показываются превью.

Разметка выделена отдельной группой с подписью «А вёрстку видно сразу — HTML и CSS открываются в превью»: ставить её в один ряд с языками неточно — HTML и CSS не исполняют, а отображают. Заголовок исправлен на «12 языков».

Заодно убран устаревший комментарий «в MVP реально исполняется только JavaScript» — серверный раннер работает и проверяется смоуком в CI.

Проверено в браузере: заголовок «12 языков — из коробки», чипы HTML и CSS отрисованы с цветными точками (#e34c26 и #563d7c), подпись на месте, горизонтального переполнения нет.