### PR TITLE
fix(db): TLS до PostgreSQL — иначе managed-база отвергает соединение

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ DATABASE_URL=postgres://runit:runit@localhost:5432/runit
 # инстансов обязаны его делить.
 DATABASE_POOL_MAX=10
 
+# Режим TLS при подключении к базе: require, prefer, verify-full, off.
+# Задавать обычно не нужно: в production по умолчанию require, иначе prefer.
+# Драйвер без этой настройки подключается открытым соединением, а
+# managed-PostgreSQL его отвергает («no pg_hba.conf entry … no encryption»).
+# verify-full требует доверенного CA — с самоподписанным сертификатом Heroku
+# он не проходит. off — только там, где TLS негде взять.
+# DATABASE_SSL=require
+
 # Именно эти строки прод считает дев-значениями и отвергает — не переносите их
 # на боевой стенд. Ключи должны различаться между собой: одинаковый секрет
 # делает refresh-токен пригодным там, где ожидается access.

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ results.json
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# Дампы базы. Скачанный с боевого стенда бэкап — это персональные данные
+# (почты и хеши паролей), и лежит он ровно там, где легко попасть под git add -A.
+*.dump
+*.sql.gz
+
 # database
 *.sqlite*
 /db/*.sqlite3*

--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Docker на PaaS обычно недоступен, поэтому сервер�
 | `HOST` | `0.0.0.0` | Интерфейс бэкенда |
 | `DATABASE_URL` | `postgres://runit:runit@localhost:5432/runit` | Строка подключения, **обязательна в production** |
 | `DATABASE_POOL_MAX` | `10` | Предел соединений на инстанс |
+| `DATABASE_SSL` | `require` в проде, иначе `prefer` | Режим TLS до базы: `require`, `prefer`, `verify-full`, `off`. Managed-PostgreSQL открытое соединение отвергает, а драйвер по умолчанию идёт без TLS |
 | `WEB_PORT` | `8080` | Внешний порт compose |
 | `NODE_ENV` | `development` | `production` требует боевых секретов и включает HSTS |
 | `LOG_LEVEL` | по `NODE_ENV` | Уровень pino: прод — `info`, разработка — `debug`, тесты — `silent` |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -57,6 +57,13 @@ export const resolveCookieSecure = (
   override?: boolean,
 ): boolean => override ?? nodeEnv === 'production';
 
+/** Режим TLS для базы — см. DATABASE_SSL в схеме ниже. */
+export const resolveDatabaseSsl = (
+  nodeEnv: 'development' | 'test' | 'production',
+  override?: 'require' | 'prefer' | 'verify-full' | 'off',
+): 'require' | 'prefer' | 'verify-full' | 'off' =>
+  override ?? (nodeEnv === 'production' ? 'require' : 'prefer');
+
 const envSchema = z
   .object({
     NODE_ENV: z
@@ -79,6 +86,34 @@ const envSchema = z
      * база начала бы отказывать.
      */
     DATABASE_POOL_MAX: z.coerce.number().int().positive().default(10),
+    /**
+     * Режим TLS при подключении к PostgreSQL (#941).
+     *
+     * Выделено в переменную, потому что драйвер postgres-js по умолчанию
+     * подключается БЕЗ шифрования, а managed-PostgreSQL его требует. На Heroku
+     * это выглядело так: приложение падало на первом же запросе миграций с
+     * «no pg_hba.conf entry for host …, no encryption», а локально и в CI всё
+     * работало — там Postgres поднят без TLS, и разница обнаружилась только на
+     * боевом стенде.
+     *
+     * Значения — как в libpq:
+     *   require     — TLS обязателен, сертификат не проверяется;
+     *   prefer      — TLS если сервер умеет, иначе открытое соединение;
+     *   verify-full — TLS с проверкой цепочки (нужен доверенный CA);
+     *   off         — без TLS.
+     *
+     * По умолчанию в production — require: боевая база всегда managed (в
+     * docker-compose.prod.yml сервиса postgres нет вовсе), а молча отправлять
+     * персональные данные по открытому каналу хуже, чем не подняться.
+     * Сертификат при этом не проверяется: у Heroku он самоподписанный, и
+     * verify-full там не проходит.
+     *
+     * Вне production — prefer: локальный Postgres из docker-compose TLS не
+     * умеет, а require к нему не подключился бы вообще.
+     */
+    DATABASE_SSL: z
+      .enum(['require', 'prefer', 'verify-full', 'off'])
+      .optional(),
     JWT_ACCESS_SECRET: secretSchema.optional(),
     JWT_REFRESH_SECRET: secretSchema.optional(),
     // Через запятую для нескольких фронтенд-origin (например, dev + staging).
@@ -127,6 +162,7 @@ const envSchema = z
     JWT_REFRESH_SECRET: raw.JWT_REFRESH_SECRET ?? DEV_REFRESH_SECRET,
     LOG_LEVEL: resolveLogLevel(raw.NODE_ENV, raw.LOG_LEVEL),
     COOKIE_SECURE: resolveCookieSecure(raw.NODE_ENV, raw.COOKIE_SECURE),
+    DATABASE_SSL: resolveDatabaseSsl(raw.NODE_ENV, raw.DATABASE_SSL),
   }))
   .superRefine((value, ctx) => {
     /**

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -24,6 +24,17 @@ const __dirname = path.dirname(__filename);
  */
 const client = postgres(env.DATABASE_URL, {
   max: env.DATABASE_POOL_MAX,
+  /**
+   * TLS. Задаётся явно, потому что у postgres-js значение по умолчанию —
+   * `ssl: false`, то есть открытое соединение, а managed-PostgreSQL его не
+   * принимает: Heroku отвечал «no pg_hba.conf entry for host …, no encryption»,
+   * и приложение падало на первом же запросе миграций (#941).
+   *
+   * Режим приходит из DATABASE_SSL (см. config/env.ts): в production require,
+   * иначе prefer. Значение 'off' приводится к false — драйвер понимает
+   * режимы libpq, но не строку 'off'.
+   */
+  ssl: env.DATABASE_SSL === 'off' ? false : env.DATABASE_SSL,
   // Приложение само сообщает об ошибках (см. monitoring.ts), драйверу
   // логировать нечего.
   onnotice: () => {},


### PR DESCRIPTION
## Зачем

Продолжение #943. После выката на боевой стенд приложение не поднялось — падало на первом же запросе миграций:

```
PostgresError: no pg_hba.conf entry for host "…", user "…", database "…", no encryption
```

Причина в значении по умолчанию у драйвера: `postgres-js` подключается с `ssl: false`, то есть открытым соединением, а managed-PostgreSQL его не принимает. Локально и в CI это не проявлялось — там Postgres поднят без TLS, и разница между стендами обнаружилась только на боевом. Старое NestJS-приложение работало потому, что SSL был настроен в TypeORM; при переходе на Drizzle настройка не переехала.

Важно: миграция схемы при этом **не запускалась**. Процесс умирал на `CREATE SCHEMA IF NOT EXISTS "drizzle"`, то есть до любых изменений — данные не пострадали.

## Что сделано

Режим вынесен в `DATABASE_SSL` и по умолчанию выводится из `NODE_ENV`: в production `require`, иначе `prefer`.

* `require` — TLS без проверки сертификата. У Heroku он самоподписанный, и `verify-full` там не проходит.
* `prefer` — пробует TLS и откатывается на открытое соединение, поэтому локальный Postgres из docker-compose работает без настройки.

Почему в проде `require`, а не `prefer`: `prefer` молча согласился бы на открытый канал, если база перестанет предлагать TLS, а сервис обрабатывает персональные данные. Боевая база всегда managed — в `docker-compose.prod.yml` сервиса postgres нет вовсе, — так что `require` ничего не ломает.

## Проверено

На Postgres с самоподписанным сертификатом, а не только на локальном без TLS — именно этот разрыв и пропустил предыдущий PR.

| Условие | Ожидание | Результат |
| --- | --- | --- |
| production (`require`), сервер **с** TLS | поднимается | ✅ `Server listening` |
| соединение реально шифровано | да | ✅ `pg_stat_ssl`: `TLSv1.3`, `TLS_AES_256_GCM_SHA384` |
| production `verify-full`, самоподписанный | отвергает | ✅ `self-signed certificate` |
| production (`require`), сервер **без** TLS | падает | ✅ `Migration failed` |
| production `DATABASE_SSL=off`, сервер без TLS | поднимается | ✅ |
| development (`prefer`), оба сервера | поднимается | ✅ |

Проверка `verify-full` здесь не формальность: она доказывает, что настройка действительно применяется, а не игнорируется драйвером.

`npm run lint`, `npx tsc --noEmit`, `npm test` (84) — зелёные.

**На боевом стенде уже выкачено**: release `v205` (`c142f504`), `web.1: up`, в логе `[static] интерфейс раздаётся из /app/frontend/dist` и `Server listening`, `Migration failed` нет.

## Заодно

`*.dump` и `*.sql.gz` в `.gitignore`. Скачанный бэкап боевой базы — это почты и хеши паролей, а лежит он в корне репозитория, где легко попадает под `git add -A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)