### PR TITLE
fix(ci): проверка типов в тестах не видела объявлений *.d.ts

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,6 +4,12 @@
     "types": ["jest", "node"],
     "noEmit": true
   },
-  "include": ["src/**/*.test.ts"],
+  // Объявления типов (*.d.ts) включены наравне с тестами, потому что иначе
+  // расширения интерфейсов до этой проверки не доходят. Тесты тянут за собой
+  // обычный код, а тот опирается на них: без src/fastify.d.ts проверка падала
+  // на `Property 'isAppPage' does not exist on type 'FastifyRequest'`, хотя
+  // основной tsc проходил. Тот же разрыв ждал global.d.ts (декларация для
+  // *.svg) — первый же тест, задевший импорт картинки, упёрся бы в него.
+  "include": ["src/**/*.test.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist", "types"]
 }


### PR DESCRIPTION
## Что было

Job «Бэкенд — линтер, типы, тесты» упал на #944 — я смержил PR с красными проверками, не посмотрев на них. Ошибка:

```
src/staticSite.ts(96,18): error TS2339: Property 'isAppPage' does not exist
on type 'FastifyRequest<…>'
```

## Почему

`tsconfig.test.json` перечислял в `include` только `src/**/*.test.ts`. Тесты тянут за собой обычный код, а тот опирается на расширение интерфейса из `src/fastify.d.ts` — но сам файл объявлений в компиляцию не попадал, и augmentation до проверки не доходил.

Отдельная причина, почему это не увидели раньше: `push.yml` прогоняет один `tsc --noEmit` по основному tsconfig, а вторую проверку — `-p tsconfig.test.json` — делает только `pull-request.yml`. То есть `main` оставался зелёным с ошибкой, которая ждала следующего PR. Я локально запускал ровно ту команду, что в `push.yml`, и мимо второй прошёл.

## Фикс

```json
"include": ["src/**/*.test.ts", "src/**/*.d.ts"]
```

Включены все `*.d.ts`, а не один `fastify.d.ts`, потому что тот же разрыв ждал `global.d.ts` с декларацией для `*.svg`: первый тест, задевший импорт картинки, упёрся бы в него точно так же.

## Проверено

Локально прогнаны **обе** команды, а не только первая:

| Команда | Результат |
| --- | --- |
| `npx tsc --noEmit -p tsconfig.test.json` | ✅ exit 0 (до фикса — 4 ошибки) |
| `npx tsc --noEmit` | ✅ exit 0 |
| `npm run lint` | ✅ |

Прода не касается: ошибка только в проверке типов, собранный код от неё не зависит — `v206` в проде работает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)