### PR TITLE
fix(ci): убрать имя компонента из тега release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "runit",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-release-commit-types": ["chore", "build"],


### PR DESCRIPTION
## Что пошло не так

Первый прогон release-please (после #946) создал релизный PR #948 со ссылкой сравнения `runit-v0.2.0...runit-v0.2.1` и заголовком `chore(main): release runit 0.2.1`. То есть тег вышел бы **`runit-v0.2.1`**, а не `v0.2.1` — вразрез с уже существующими `v0.1.0` и `v0.2.0`.

Хуже второе следствие: тега `runit-v0.2.0` не существует, поэтому предыдущий выпуск не нашёлся и в CHANGELOG уехала **вся история проекта** вместо трёх коммитов после `v0.2.0` — там и `#848`, и `#914`, и `header start`.

## Причина

По умолчанию release-please подставляет в тег имя компонента, а компонент для `release-type: node` берётся из `package-name`. Я скопировал конфиг с `hexlet-basics`, не заметив, что у него это поведение так и оставлено — проверил их релизы, теги действительно `hexlet_basics-v0.1.3`. А `hexlet/hexlet` выключает это явно (`"include-component-in-tag": false`) и получает `v0.1.107`.

Нам нужен второй вариант: линия тегов `v0.1.0` → `v0.2.0` уже существует, прерывать её нельзя.

## Фикс

```json
"include-component-in-tag": false
```

После мержа release-please пересоберёт релизный PR: тег станет `v0.2.1`, предыдущий выпуск найдётся, и CHANGELOG соберётся из коммитов после `v0.2.0`.

**#948 мержить не надо** — он закроется сам или его можно закрыть руками.

## Замечание

Работоспособность самой схемы это подтвердило: release-please отработал, права на создание PR есть, релизный PR появился. Ошибка была в одном ключе конфигурации, а не в устройстве конвейера.

🤖 Generated with [Claude Code](https://claude.com/claude-code)