### PR TITLE
fix(editor): различать «сервер не отвечает» и «исполнение недоступно»

### DIFF
--- a/frontend/src/v2/shared/runner/server.test.ts
+++ b/frontend/src/v2/shared/runner/server.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest';
+import { type RunnerClient, runOnServer } from './server';
+
+/**
+ * Клиент серверного исполнения.
+ *
+ * Главное, что здесь проверяется, — различение двух разных бед, которые раньше
+ * сливались в одну строку «Сервер исполнения недоступен, попробуйте позже»:
+ *
+ *  * приложение вообще не отвечает (упало, нет сети) — тогда дело не в раннере,
+ *    и искать причину в нём бесполезно. Ровно на это и наткнулись: бэкенд был
+ *    остановлен, а сообщение указывало на исполнение кода;
+ *  * сервер ответил, но исполнение недоступно — тогда у ответа есть свой
+ *    понятный текст, и подменять его нельзя.
+ */
+
+const clientThatThrows = (error: unknown): RunnerClient => ({
+  runner: {
+    run: {
+      mutate: async () => {
+        throw error;
+      },
+    },
+  },
+});
+
+const params = { language: 'python' as const, code: 'print(1)' };
+
+describe('сбой связи', () => {
+  test('сервер не отвечает — говорим про связь, а не про раннер', async () => {
+    const out = await runOnServer(clientThatThrows(new TypeError('fetch failed')), params);
+
+    const text = out.lines[0].text;
+    expect(text).toContain('связаться с сервером');
+    expect(text).not.toContain('исполнения недоступен');
+    expect(out.exitCode).toBe(1);
+  });
+
+  test('истёкшее ожидание названо своим именем и с числом секунд', async () => {
+    const timeout = new DOMException('The operation timed out', 'TimeoutError');
+
+    const out = await runOnServer(clientThatThrows(timeout), params, 30_000);
+
+    expect(out.lines[0].text).toContain('30');
+    expect(out.lines[0].text).toMatch(/не пришёл|перегружен/i);
+  });
+
+  test('таймаут узнаётся и когда клиент завернул его в свою ошибку', async () => {
+    // tRPC оборачивает исходную ошибку, поэтому смотрим и на cause.
+    const wrapped = Object.assign(new Error('failed'), {
+      cause: new DOMException('aborted', 'AbortError'),
+    });
+
+    const out = await runOnServer(clientThatThrows(wrapped), params, 20_000);
+
+    expect(out.lines[0].text).toContain('20');
+  });
+});
+
+describe('ответ сервера', () => {
+  test('недоступное исполнение показывается сообщением сервера', async () => {
+    const client: RunnerClient = {
+      runner: {
+        run: {
+          mutate: async () => ({
+            status: 'unavailable' as const,
+            message: 'Серверное исполнение сейчас недоступно. Попробуйте позже.',
+            exitCode: null,
+          }),
+        },
+      },
+    };
+
+    const out = await runOnServer(client, params);
+
+    expect(out.lines.some((l) => l.text.includes('Серверное исполнение'))).toBe(
+      true,
+    );
+  });
+
+  test('успешный запуск отдаёт вывод и код возврата', async () => {
+    const client: RunnerClient = {
+      runner: {
+        run: {
+          mutate: async () => ({
+            status: 'ok' as const,
+            stdout: 'привет\n',
+            exitCode: 0,
+            durationMs: 42,
+          }),
+        },
+      },
+    };
+
+    const out = await runOnServer(client, params);
+
+    expect(out.exitCode).toBe(0);
+    expect(out.lines.some((l) => l.text === 'привет')).toBe(true);
+  });
+});

--- a/frontend/src/v2/shared/runner/server.ts
+++ b/frontend/src/v2/shared/runner/server.ts
@@ -100,6 +100,20 @@ export function toRunResult(out: ServerRunOutput): RunResult {
   };
 }
 
+/**
+ * Отличает истёкшее ожидание от обрыва связи.
+ *
+ * AbortSignal.timeout бросает DOMException с именем TimeoutError, а клиент tRPC
+ * заворачивает её в свою ошибку — поэтому смотрим и на саму ошибку, и на
+ * причину.
+ */
+const isTimeout = (error: unknown): boolean => {
+  const names = [error, (error as { cause?: unknown } | null)?.cause]
+    .filter(Boolean)
+    .map((e) => (e as { name?: string }).name);
+  return names.includes('TimeoutError') || names.includes('AbortError');
+};
+
 export async function runOnServer(
   client: RunnerClient,
   params: { language: ServerLanguage; code: string; stdin?: string },
@@ -112,13 +126,24 @@ export async function runOnServer(
       signal: AbortSignal.timeout(timeoutMs),
     });
     return toRunResult(out);
-  } catch {
-    // Сеть недоступна / сервер не отвечает — не роняем UI и не крутим спиннер вечно.
+  } catch (error) {
+    /**
+     * Сюда попадают только сбои связи: если сервер ответил, но исполнение
+     * недоступно (нет docker, язык выключен), это нормальный ответ со статусом
+     * unavailable и своим сообщением — он идёт через toRunResult выше.
+     *
+     * Прежний текст «Сервер исполнения недоступен» этих случаев не различал и
+     * вводил в заблуждение: при остановленном бэкенде человек читал, что не
+     * работает запуск кода, и шёл искать проблему в раннере — хотя не отвечало
+     * само приложение.
+     */
     return {
       lines: [
         {
           type: 'system',
-          text: 'Сервер исполнения недоступен, попробуйте позже.',
+          text: isTimeout(error)
+            ? `Ответ не пришёл за ${Math.round(timeoutMs / 1000)} с. Запуск слишком долгий или сервер перегружен.`
+            : 'Не удалось связаться с сервером — проверьте соединение и попробуйте снова.',
         },
       ],
       exitCode: 1,


### PR DESCRIPTION
При запуске python в консоли появилось «Сервер исполнения недоступен, попробуйте позже». Причина была другая: остановлен бэкенд — не отвечало само приложение. Сообщение указывало на раннер и уводило искать проблему не там.

Этот текст стоял в ветке `catch`, куда попадают **только сбои связи**. Если сервер ответил, но исполнение недоступно (нет docker, язык выключен) — это нормальный ответ со статусом `unavailable` и собственным понятным сообщением, оно идёт другим путём.

## Стало

| Что случилось | Что видит человек |
| --- | --- |
| Приложение не отвечает | «Не удалось связаться с сервером — проверьте соединение и попробуйте снова» |
| Ответ не пришёл вовремя | «Ответ не пришёл за 30 с. Запуск слишком долгий или сервер перегружен» |
| Сервер ответил «исполнение недоступно» | сообщение сервера, без подмены |

Таймаут узнаётся и когда клиент tRPC заворачивает исходную ошибку — смотрим и на `cause`.

## Проверка

Пять новых тестов (на фронтенде теперь 87): обрыв связи, таймаут с числом секунд, завёрнутый таймаут, ответ `unavailable` показывается как есть, успешный запуск отдаёт вывод и код возврата.

Вживую после перезапуска бэкенда: python-сниппет в редакторе выполнился — «питон из браузера 42», код 0 за 323 мс.