### PR TITLE
fix(runner): не путать сбой docker с несобранным образом

### DIFF
--- a/src/runner/availability.test.ts
+++ b/src/runner/availability.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { looksLikeDaemonProblem } from './availability';
+
+/**
+ * Разбор ошибок docker при проверке образа.
+ *
+ * Случай из практики: во время обновления Docker Desktop `docker image inspect`
+ * отвечал «No such image» на существующий образ — `docker images` его показывал,
+ * а `docker run` с ним работал. Приложение объявляло, что образ не собран, и
+ * советовало пересобрать все девять. Совет был бесполезным: нужно было
+ * подождать, пока демон вернётся.
+ *
+ * Отличить эти два состояния можно только по тексту ошибки самого docker,
+ * поэтому набор строк зафиксирован тестом.
+ */
+
+test('сбой демона узнаётся по типичным сообщениям docker', () => {
+  const daemonErrors = [
+    'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    'error during connect: Get "http://docker/v1.47/version": EOF',
+    'dial unix /var/run/docker.sock: connect: connection refused',
+    'context deadline exceeded',
+    'The docker daemon is not running',
+  ];
+
+  for (const message of daemonErrors) {
+    assert.equal(
+      looksLikeDaemonProblem(message),
+      true,
+      `не распознано как сбой демона: ${message}`,
+    );
+  }
+});
+
+test('отсутствие образа остаётся отсутствием образа', () => {
+  // Здесь совет «соберите образы» уместен, и подменять его нельзя.
+  assert.equal(
+    looksLikeDaemonProblem(
+      'Error response from daemon: No such image: runit-runner-python:1',
+    ),
+    false,
+  );
+  assert.equal(
+    looksLikeDaemonProblem('Error: No such object: runit-runner-go:1'),
+    false,
+  );
+  assert.equal(looksLikeDaemonProblem(''), false);
+});

--- a/src/runner/availability.ts
+++ b/src/runner/availability.ts
@@ -102,6 +102,23 @@ export async function checkDaemon(): Promise<Availability> {
   return remember('daemon', { ok: true });
 }
 
+/**
+ * Отличает «образа нет» от «демон не ответил».
+ *
+ * `docker image inspect` возвращает ненулевой код в обоих случаях, и раньше оба
+ * объяснялись одинаково — «Образ не собран, выполните runner:build-images».
+ * Совет бывал прямо вредным: во время обновления Docker Desktop демон
+ * отказывался отвечать на inspect по имени, притом что образ был на месте и
+ * `docker run` с ним работал. Человеку предлагалось пересобирать девять
+ * образов, хотя нужно было подождать полминуты.
+ *
+ * Разбираем по тексту ошибки самого docker — другого признака у CLI нет.
+ */
+export const looksLikeDaemonProblem = (stderr: string): boolean =>
+  /cannot connect to the docker daemon|is the docker daemon running|daemon is not running|connection refused|context deadline exceeded|EOF/i.test(
+    stderr,
+  );
+
 export async function checkImage(language: string): Promise<Availability> {
   const tag = imageTagFor(language);
   const hit = cached(`image:${tag}`);
@@ -117,8 +134,24 @@ export async function checkImage(language: string): Promise<Availability> {
     env: dockerEnv(),
   });
 
-  if (result.exitCode !== 0) {
+  if (result.exitCode !== 0 || result.spawnErrorCode) {
     logProbe(`docker image inspect ${tag}`, result.stderr);
+
+    if (result.spawnErrorCode || looksLikeDaemonProblem(result.stderr)) {
+      /**
+       * Сбой демона, а не отсутствие образа. Не запоминаем это как приговор
+       * образу: отрицательный кэш живёт секунды, поэтому после возвращения
+       * демона язык заработает сам, без перезапуска приложения.
+       */
+      return {
+        ok: false,
+        reason: 'no_daemon',
+        message: audienceMessage(
+          'Docker сейчас не отвечает (перезапуск или обновление). Повторите через полминуты.',
+        ),
+      };
+    }
+
     return remember(`image:${tag}`, {
       ok: false,
       reason: 'no_image',


### PR DESCRIPTION
Все девять серверных языков разом ответили «Серверное исполнение сейчас недоступно», хотя ничего не менялось.

## Что произошло

Обновлялся Docker Desktop. В этот момент `docker image inspect runit-runner-python:1` отвечал `No such image` — притом что образ был на месте:

```
docker images   → runit-runner-python:1  (201MB, 30 hours ago)
docker run      → «образ запускается»
docker inspect  → Error response from daemon: No such image
```

Приложение видело ненулевой код возврата и делало единственный вывод, который умело: «Образ не собран. Выполните: npm run runner:build-images». Совет вёл в никуда — пересобирать девять образов было не нужно, нужно было подождать полминуты.

## Что изменено

`docker image inspect` возвращает ненулевой код и когда образа нет, и когда демон не отвечает. Различить можно только по тексту ошибки — теперь он разбирается:

| Ошибка docker | Что видит человек |
| --- | --- |
| `Cannot connect to the Docker daemon`, `connection refused`, `EOF`, `context deadline exceeded` | «Docker сейчас не отвечает (перезапуск или обновление). Повторите через полминуты» |
| `No such image` | «Образ … не собран. Выполните: npm run runner:build-images» |

Важная деталь: сбой демона **не попадает в кэш** как приговор образу. Раньше отрицательный результат запоминался под ключом образа, теперь язык заработает сам, как только демон вернётся, — без перезапуска приложения.

## Проверка

Два теста на разбор сообщений (тестов раннера стало 40): набор типичных ошибок недоступного демона и отдельно — сообщения об отсутствующем образе, где прежний совет остаётся правильным.

На живом стенде после возвращения демона: смоук 16 из 16, включая все девять языков, stdin, таймаут, изоляцию сети, fork-бомбу и обрезку вывода.