### PR TITLE
fix(editor): предупреждать о недоступном исполнении заранее, а не после запуска

### DIFF
--- a/frontend/src/v2/pages/editor/ui/EditorPage.tsx
+++ b/frontend/src/v2/pages/editor/ui/EditorPage.tsx
@@ -23,6 +23,7 @@ import { useSession } from '../../../entities/user';
 
 import { ConsolePanel } from '../../../features/run-code';
 import { isPreviewLanguage } from '../../../shared/runner/preview';
+import { unavailableReason, useRunnerStatus } from '../../../shared/runner';
 import { ShareModal } from '../../../features/share-snippet';
 import AddPackageModal from './AddPackageModal';
 
@@ -89,6 +90,13 @@ export default function EditorPage() {
    * Расположение консоли учитывается только на широком экране: на узком панели
    * переключаются кнопкой (#842), делить там высоту не на чем.
    */
+  /**
+   * Доступно ли серверное исполнение на этом стенде. Спрашиваем заранее, чтобы
+   * не выяснять это нажатием «Выполнить»: на PaaS без docker девять языков не
+   * запускаются в принципе, и человек видел это только по ошибке в консоли.
+   */
+  const runnerStatus = useRunnerStatus(trpc as never);
+
   const prefs = useEditorPrefs();
   const consoleAtBottom = !isMobile && prefs.consoleLayout === 'bottom';
 
@@ -300,6 +308,9 @@ export default function EditorPage() {
     );
   }
 
+  /** Текст о том, почему этот язык здесь не запустится (null — запустится). */
+  const runnerBlocked = unavailableReason(language, runnerStatus);
+
   const meta = langMeta[language] ?? {
     label: language,
     dot: '#adb5bd',
@@ -332,6 +343,15 @@ export default function EditorPage() {
         running={running}
         markDirty={markDirty}
       />
+
+      {runnerBlocked && (
+        <Alert color="yellow" radius={0} py={8}>
+          <Text fz="sm">
+            {runnerBlocked} Запускать можно JavaScript (выполняется в браузере) и
+            HTML/CSS (превью).
+          </Text>
+        </Alert>
+      )}
 
       {isForeign && (
         <Alert color="yellow" radius={0} py={8}>

--- a/frontend/src/v2/shared/runner/index.ts
+++ b/frontend/src/v2/shared/runner/index.ts
@@ -6,6 +6,12 @@ export type { ConsoleLine, RunResult } from './types';
 export type { RunnerClient, ServerLanguage, ServerRunOutput } from './server';
 export { runJavaScript } from './javascript';
 export { toRunResult } from './server';
+export {
+  RUNNER_STATUS_QUERY_KEY,
+  unavailableReason,
+  useRunnerStatus,
+} from './useRunnerStatus';
+export type { RunnerStatus, RunnerStatusClient } from './useRunnerStatus';
 
 /**
  * Языки, которые исполняет сервер (в docker) — список должен совпадать с

--- a/frontend/src/v2/shared/runner/useRunnerStatus.test.ts
+++ b/frontend/src/v2/shared/runner/useRunnerStatus.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { type RunnerStatus, unavailableReason } from './useRunnerStatus';
+
+/**
+ * Предупреждение о недоступном серверном исполнении.
+ *
+ * Случай, ради которого это появилось: боевой стенд развёрнут на PaaS, где
+ * docker недоступен в принципе. Девять серверных языков там не запускаются
+ * никогда, но узнать об этом можно было только написав код и нажав «Выполнить»
+ * — то есть свойство площадки выглядело как поломка сайта.
+ */
+
+const status = (over: Partial<RunnerStatus> = {}): RunnerStatus => ({
+  languages: ['python', 'php', 'ruby', 'java', 'typescript', 'go', 'cpp', 'sql', 'bash'],
+  available: true,
+  message: null,
+  ...over,
+});
+
+describe('когда предупреждать', () => {
+  test('серверный язык на стенде без раннера — предупреждаем словами сервера', () => {
+    const reason = unavailableReason(
+      'php',
+      status({ available: false, message: 'Серверное исполнение сейчас недоступно.' }),
+    );
+
+    expect(reason).toBe('Серверное исполнение сейчас недоступно.');
+  });
+
+  test('сервер молчит о причине — объясняем сами', () => {
+    const reason = unavailableReason('python', status({ available: false, message: null }));
+
+    expect(reason).toContain('не запустится');
+  });
+
+  test('язык выключен на этом стенде — называем язык', () => {
+    const reason = unavailableReason(
+      'go',
+      status({ languages: ['python', 'php'] }),
+    );
+
+    expect(reason).toContain('go');
+  });
+});
+
+describe('когда молчать', () => {
+  test('раннер работает — предупреждать не о чем', () => {
+    expect(unavailableReason('python', status())).toBeNull();
+  });
+
+  test('JavaScript и разметка не зависят от сервера', () => {
+    // Они исполняются в браузере, поэтому недоступный раннер им не помеха —
+    // предупреждение было бы ложной тревогой.
+    const dead = status({ available: false, message: 'нет docker' });
+    expect(unavailableReason('javascript', dead)).toBeNull();
+    expect(unavailableReason('html', dead)).toBeNull();
+    expect(unavailableReason('css', dead)).toBeNull();
+  });
+
+  test('пока статус не пришёл — молчим', () => {
+    // Иначе предупреждение мигало бы на каждой загрузке редактора.
+    expect(unavailableReason('php', null)).toBeNull();
+  });
+});

--- a/frontend/src/v2/shared/runner/useRunnerStatus.ts
+++ b/frontend/src/v2/shared/runner/useRunnerStatus.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import { SERVER_LANGUAGES } from '.';
+
+/**
+ * Доступно ли серверное исполнение на этом стенде.
+ *
+ * Нужно, чтобы сказать человеку правду заранее, а не после нажатия «Выполнить».
+ * Ровно на этом обожглись: сайт развёрнут на PaaS, где docker недоступен в
+ * принципе, поэтому все девять серверных языков отвечают «Серверное исполнение
+ * сейчас недоступно» — но узнать это можно было только написав код и запустив
+ * его. Выглядит как поломка, хотя это свойство площадки.
+ *
+ * Статус спрашиваем один раз на сессию: он меняется не чаще, чем разворачивают
+ * стенд, а лишний запрос на каждой странице редактора ни к чему.
+ */
+
+export interface RunnerStatus {
+  languages: string[];
+  available: boolean;
+  message: string | null;
+}
+
+export interface RunnerStatusClient {
+  runner: { status: { query: () => Promise<RunnerStatus> } };
+}
+
+export const RUNNER_STATUS_QUERY_KEY = ['runner-status'] as const;
+
+export function useRunnerStatus(client: RunnerStatusClient) {
+  const { data } = useQuery({
+    queryKey: RUNNER_STATUS_QUERY_KEY,
+    queryFn: () => client.runner.status.query(),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+  });
+
+  return data ?? null;
+}
+
+/**
+ * Почему этот язык нельзя запустить здесь, или null, если можно.
+ *
+ * Пока статус не получен, молчим: пустая подсказка лучше, чем предупреждение,
+ * которое через секунду исчезнет.
+ */
+export function unavailableReason(
+  language: string,
+  status: RunnerStatus | null,
+): string | null {
+  if (!status) return null;
+  if (!SERVER_LANGUAGES.has(language)) return null;
+
+  if (!status.available) {
+    return (
+      status.message ??
+      'Серверное исполнение на этом стенде недоступно — код не запустится.'
+    );
+  }
+  if (!status.languages.includes(language)) {
+    return `Язык ${language} на этом стенде отключён — код не запустится.`;
+  }
+  return null;
+}


### PR DESCRIPTION
На боевом сайте PHP-сниппет отвечает «Серверное исполнение сейчас недоступно. Попробуйте позже». Это не поломка: стенд развёрнут на PaaS, где docker недоступен в принципе, поэтому девять серверных языков там не запускаются никогда.

Проблема в том, **когда** человек это узнаёт: только написав код и нажав «Выполнить». Свойство площадки выглядит как сломанный сайт.

## Что сделано

Редактор спрашивает `runner.status` при открытии (один раз на сессию) и, если язык сниппета здесь не запустится, говорит об этом сразу — полосой над редактором, причиной от сервера и подсказкой, что JavaScript и HTML/CSS работают всегда, потому что исполняются в браузере.

Предупреждение молчит там, где тревога была бы ложной:
- для `javascript`, `html`, `css` — они не зависят от сервера;
- пока статус не получен — иначе полоса мигала бы на каждой загрузке;
- когда раннер работает.

Отдельно различается «раннер выключен целиком» и «этот язык отключён на стенде» (`RUNNER_LANGUAGES`) — во втором случае язык называется.

## Проверка

Шесть тестов на логику предупреждения, на фронтенде теперь 93.

Вживую с `RUNNER_ENABLED=false` (как на боевом стенде): у python-сниппета появляется полоса «Серверное исполнение отключено… Запускать можно JavaScript (выполняется в браузере) и HTML/CSS (превью)», у JavaScript её нет, и код в браузере выполняется как обычно — `JS работает и без раннера: 42`.

## Что это не чинит

Сами девять языков на боевом стенде не заработают, пока у приложения нет доступа к docker-демону. Это отдельная задача: нужен runner-хост (rootless или удалённый демон) и `DOCKER_HOST` — схемы описаны в README.