### PR TITLE
perf(frontend): убрать блокирующие Google Fonts и показать загрузку вместо пустого экрана

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,16 +5,30 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Runit</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Golos+Text:wght@400;500;600;700;800&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap"
-      rel="stylesheet"
-    />
+    <!--
+      Шрифты подключаются из сборки (src/v2/app/AppProviders.tsx), а не с
+      fonts.googleapis.com. Внешний <link rel="stylesheet"> в <head> блокирует
+      отрисовку: пока чужой сервер не ответит, страница не рисуется вообще, — а
+      из России этот хост отвечает нестабильно.
+    -->
   </head>
 
   <body>
-    <div id="main"></div>
+    <!--
+      Заглушка до запуска приложения. Без неё страница до исполнения JS пустая:
+      в #main ничего нет, фон не задан, и человек видит белый экран (или цвет
+      темы браузера), не понимая, грузится ли что-нибудь. Разметка инлайновая
+      намеренно — она обязана работать до того, как приедут стили и скрипты.
+      React заменяет содержимое #main при монтировании.
+    -->
+    <div id="main">
+      <div style="min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;background:#f8f9fa;color:#495057;font:500 15px/1.5 system-ui,-apple-system,sans-serif">
+        <div style="width:34px;height:34px;border:3px solid #dee2e6;border-top-color:#4dabf7;border-radius:50%;animation:runit-spin .9s linear infinite"></div>
+        <div>Загружаем Runit…</div>
+        <noscript>Для работы редактора нужен включённый JavaScript.</noscript>
+      </div>
+    </div>
+    <style>@keyframes runit-spin{to{transform:rotate(360deg)}}</style>
     <script src="./src/index.js" type="module">
     </script>
   </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/golos-text": "^5.3.0",
+        "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@mantine/core": "^8.3.5",
         "@mantine/form": "^8.3.10",
         "@mantine/hooks": "^8.3.5",
@@ -1123,6 +1125,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/golos-text": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/golos-text/-/golos-text-5.3.0.tgz",
+      "integrity": "sha512-D+Evz5yqXYh6tsalc537FS+cPDWn2FTdO8j/K1ZZuFAvA7ib6WnusTiihciq7mMnm6GBo6XTlh0JXPrhBsam2g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fontsource-variable/golos-text": "^5.3.0",
+    "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@mantine/core": "^8.3.5",
     "@mantine/form": "^8.3.10",
     "@mantine/hooks": "^8.3.5",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,48 @@ import ReactDOM from 'react-dom/client';
 
 import app from './application.tsx';
 
+/**
+ * Сбой загрузки части приложения.
+ *
+ * После выката имена файлов сборки меняются. Открытая вкладка со старой
+ * страницей просит файл, которого больше нет: Vite сообщает об этом событием
+ * vite:preloadError, а человек до сих пор видел пустой экран и ничего не мог
+ * сделать. Перезагружаем один раз — этого достаточно, чтобы получить свежий
+ * index.html. Признак храним в sessionStorage, иначе при недоступности файла по
+ * другой причине получился бы цикл перезагрузок.
+ */
+const RELOAD_MARK = 'runit.reloadedAfterChunkError';
+
+window.addEventListener('vite:preloadError', () => {
+  if (sessionStorage.getItem(RELOAD_MARK)) return;
+  sessionStorage.setItem(RELOAD_MARK, '1');
+  window.location.reload();
+});
+
+/** Показывает причину вместо пустого экрана, если приложение не поднялось. */
+const showStartupError = () => {
+  const root = document.getElementById('main');
+  if (!root) return;
+  root.innerHTML = `
+    <div style="min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;background:#f8f9fa;color:#495057;font:500 15px/1.5 system-ui,-apple-system,sans-serif;padding:20px;text-align:center">
+      <div style="font-size:17px;font-weight:700;color:#212529">Не удалось загрузить Runit</div>
+      <div>Проверьте соединение и обновите страницу.</div>
+      <button type="button" onclick="location.reload()" style="margin-top:6px;padding:8px 18px;border:0;border-radius:8px;background:#4dabf7;color:#fff;font:600 15px system-ui;cursor:pointer">
+        Обновить
+      </button>
+    </div>`;
+};
+
 const run = async () => {
-  const root = ReactDOM.createRoot(document.getElementById('main'));
-  const dom = await app();
-  root.render(dom);
+  try {
+    const root = ReactDOM.createRoot(document.getElementById('main'));
+    const dom = await app();
+    root.render(dom);
+    sessionStorage.removeItem(RELOAD_MARK);
+  } catch (error) {
+    console.error('Runit не запустился:', error);
+    showStartupError();
+  }
 };
 
 run();

--- a/frontend/src/v2/app/AppProviders.tsx
+++ b/frontend/src/v2/app/AppProviders.tsx
@@ -1,3 +1,20 @@
+/**
+ * Шрифты со своего домена, а не из Google Fonts.
+ *
+ * Раньше index.html подключал fonts.googleapis.com обычным <link rel="stylesheet">
+ * в <head> — то есть отрисовка страницы ждала ответа чужого сервера. Из России
+ * этот хост отвечает нестабильно, и пока браузер его ждёт, человек видит пустой
+ * экран: в index.html до запуска JS не было ни строчки содержимого. Отсюда и
+ * «иногда грузится оооочень долго».
+ *
+ * Теперь шрифты — часть сборки: отдаются с нашего адреса, с бессрочным кэшем
+ * (assets помечены immutable) и без обращений к третьим лицам. Заодно к
+ * посетителям не уходит запрос к Google, то есть их IP туда не передаётся —
+ * для 152-ФЗ это тоже к месту.
+ */
+import '@fontsource-variable/golos-text';
+import '@fontsource-variable/jetbrains-mono';
+
 import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
 


### PR DESCRIPTION
Жалоба: сайт «иногда грузится оооочень долго», иногда вместо страницы — пустой экран.

## Сервер не виноват

Замерил живой стенд:

| Что | Результат |
| --- | --- |
| TTFB `index.html` | 0,67 с |
| Бандл JS | 536 КБ → **167 КБ** после brotli |
| Кэш ассетов | `public, max-age=31536000, immutable` |
| Аптайм приложения | 83 968 с (сутки) — дино не спит и не перезапускается |

## Виноваты две вещи в самой странице

**1. Блокирующие Google Fonts.** `index.html` подключал `fonts.googleapis.com` обычным `<link rel="stylesheet">` в `<head>`. Такой запрос блокирует отрисовку: пока чужой сервер не ответит, браузер не рисует **ничего**. Из России этот хост отвечает нестабильно — вот и «очень долго», и пустой экран на всё время ожидания.

**2. До запуска JS страница пустая.** В `index.html` был только `<div id="main"></div>` — ни текста, ни фона. Любая задержка или сбой давали белый экран (или цвет темы браузера, как на скриншоте) без единого слова о том, что происходит.

## Что сделано

- **Шрифты переехали в сборку** (`@fontsource-variable/golos-text`, `@fontsource-variable/jetbrains-mono`): отдаются с нашего адреса, кэшируются бессрочно, внешних запросов со страницы не остаётся вовсе. Побочная польза: IP посетителей больше не уходит в Google — для 152-ФЗ это тоже к месту.
- **Заглушка до загрузки**: инлайновый спиннер и «Загружаем Runit…» прямо в `index.html`, плюс `<noscript>` для выключенного JavaScript. React заменяет её при монтировании. Разметка инлайновая намеренно — она обязана работать до того, как приедут стили и скрипты.
- **Сбой загрузки чанка больше не даёт пустой экран.** После выката имена файлов меняются, и старая вкладка просит удалённый файл. Теперь `vite:preloadError` перезагружает страницу один раз (признак в `sessionStorage`, чтобы не устроить цикл), а если приложение всё равно не поднялось — показывается объяснение и кнопка «Обновить».

## Проверка

В собранном `index.html` не осталось ни одного `https`-адреса. Страница поднимается с **нулём внешних запросов**, шрифт применён (`Golos Text`), лендинг рисуется. 93 теста фронтенда, линтер, типы и `npm audit --omit=dev` — чистые.